### PR TITLE
feat: direct object editing & toolbar redesign for slide editor

### DIFF
--- a/docs/plans/2026-03-06-editor-direct-object-edit-design.md
+++ b/docs/plans/2026-03-06-editor-direct-object-edit-design.md
@@ -1,0 +1,117 @@
+# Editor Direct Object Edit Design
+
+## Goal
+
+Add a second editor mode that lets the user click a slide object inside the iframe and apply a limited set of immediate edits without going through Codex. The existing bbox workflow remains the default mode.
+
+## Scope
+
+In scope:
+- Keep bbox drawing as the default interaction mode.
+- Add a top toolbox for mode switching and direct-edit controls.
+- Add object hover and selection overlays in select mode.
+- Support immediate edits for:
+  - text content
+  - text color
+  - background color
+  - font size
+  - bold
+  - italic
+  - underline
+  - strikethrough
+  - text alignment
+- Persist direct edits back to the slide HTML file.
+
+Out of scope:
+- layout reflow or re-positioning
+- drag/move/resize
+- arbitrary CSS property editing
+- multi-object editing
+- editing multiple slides at once
+
+## Constraints
+
+- The editor already renders slides in an iframe with same-origin access, so DOM hit-testing is viable.
+- Current bbox behavior and Codex edit flow must remain intact.
+- Reloading the iframe after every direct edit would make text editing unusable, so local saves must avoid unnecessary refresh churn.
+- The implementation should favor stability over breadth; text-oriented styling is the safe first slice.
+
+## Recommended Approach
+
+Use a dual-mode overlay inside the existing slide wrapper:
+
+1. `bbox` mode
+   - Keep current draw-layer behavior as-is.
+   - Existing bbox review actions remain available.
+
+2. `select` mode
+   - Reuse the overlay area to track pointer position.
+   - Resolve the hovered element with `elementFromPoint()` inside the iframe document.
+   - Ignore `html`, `head`, and `body`.
+   - Show hover and selected outlines on top of the slide.
+   - Bind a compact direct-edit toolbar to the selected element.
+
+For persistence, apply changes directly to the iframe DOM and save the full updated slide HTML through a new server endpoint. This is simpler and safer than trying to patch source text with ad hoc string manipulation. To preserve editing flow, the client should mark recent local saves and ignore the next matching `fileChanged` event for that slide.
+
+## UI Design
+
+Add a toolbox above the slide iframe area with:
+- mode toggle buttons: `Draw Boxes`, `Select Object`
+- object summary chip: selected tag and short text preview
+- direct-edit controls shown only in select mode when an object is selected
+
+Direct-edit controls:
+- text input for text-capable elements
+- color input for text color
+- color input for background color
+- number input for font size
+- toggle buttons: bold, italic, underline, strikethrough
+- alignment buttons: left, center, right
+
+Behavior:
+- Switching to select mode disables bbox drawing.
+- Existing bbox overlays remain in state, but bbox interaction stays tied to draw mode.
+- Selecting an object updates the toolbar state from computed styles.
+- Each control applies changes immediately to the live iframe DOM and persists them.
+
+## Data Flow
+
+### Selection
+
+1. Pointer moves over overlay in select mode.
+2. Client converts viewport coordinates to slide coordinates.
+3. Client resolves the iframe element under that point.
+4. Client stores the selected element XPath in slide state.
+5. Overlay box is rendered from the element bounding rect.
+
+### Direct Edit
+
+1. User changes a control in the toolbox.
+2. Client updates the selected DOM element inline style or text content.
+3. Client serializes the iframe document with doctype.
+4. Client POSTs updated HTML to the server for the current slide.
+5. Server writes the file and responds.
+6. Client suppresses the immediate self-triggered reload event for that slide.
+
+## Error Handling
+
+- If no valid element is under the cursor, hover state is cleared.
+- If the selected element disappears after a reload, selection is cleared gracefully.
+- Failed save requests should keep the local change visible but report the failure in the status bar and chat log.
+- Text editing controls should be disabled for elements with nested child elements where replacing `textContent` would be destructive.
+
+## Testing Strategy
+
+- Add editor UI e2e coverage for:
+  - switching from bbox mode to select mode
+  - selecting an object in the iframe
+  - editing text and style controls
+  - verifying saved HTML contains the expected inline styles/text
+  - switching back to bbox mode and ensuring drawing still works
+- Add focused unit coverage for any new pure helper functions introduced for direct-edit state or serialization.
+
+## Risks
+
+- Saving serialized HTML can normalize formatting. This is acceptable for the first version because it preserves structure and behavior while keeping implementation scope contained.
+- Some elements may derive styles from inherited CSS rather than inline styles. The toolbar should read computed styles, then write explicit inline overrides.
+- Background color controls are less meaningful on transparent text nodes, but still useful for blocks and labels.

--- a/docs/plans/2026-03-06-editor-direct-object-edit.md
+++ b/docs/plans/2026-03-06-editor-direct-object-edit.md
@@ -1,0 +1,110 @@
+# Editor Direct Object Edit Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a select-object mode to the slide editor so users can click slide DOM elements and immediately edit limited text and style properties while preserving the existing bbox workflow as the default mode.
+
+**Architecture:** Extend the current inline editor client with a second interaction mode and a direct-edit toolbar. Persist edits by updating the iframe DOM locally, serializing the slide HTML, and writing it through a new server endpoint while suppressing self-triggered iframe reloads.
+
+**Tech Stack:** HTML/CSS/vanilla JS in `src/editor/editor.html`, Node.js + Express in `scripts/editor-server.js`, Playwright-based Node e2e tests
+
+---
+
+### Task 1: Capture the new behavior with failing editor e2e coverage
+
+**Files:**
+- Modify: `tests/editor/editor-ui.e2e.test.js`
+
+**Step 1: Write the failing test**
+
+Add an e2e test that:
+- starts the editor server with temp slides
+- switches the tool mode from bbox to object select
+- clicks an `h1` in the iframe
+- edits the selected object text, color, font weight, strikethrough, and alignment
+- verifies the slide file on disk contains the changed text and inline styles
+- switches back to bbox mode and confirms bbox drawing still works
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js`
+Expected: FAIL because the tool mode UI and direct-edit controls do not exist yet
+
+**Step 3: Keep the failing assertions focused**
+
+If the first failure is too early or ambiguous, tighten selectors/assertions until the test fails specifically on missing object-edit UI behavior.
+
+### Task 2: Add direct-edit save support to the editor server
+
+**Files:**
+- Modify: `scripts/editor-server.js`
+
+**Step 1: Write or extend failing coverage first**
+
+Rely on the e2e added in Task 1 to fail on missing save behavior.
+
+**Step 2: Write minimal implementation**
+
+Add a JSON endpoint that:
+- validates the slide filename
+- accepts updated HTML content
+- writes it to the correct slide file
+- returns a success payload
+
+Keep the existing `/api/apply` flow unchanged.
+
+**Step 3: Run the targeted test**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js`
+Expected: Still FAIL, but later, because the client UI is not implemented yet
+
+### Task 3: Implement select-object mode and inline direct-edit controls
+
+**Files:**
+- Modify: `src/editor/editor.html`
+
+**Step 1: Write the minimal client implementation to satisfy the test**
+
+Add:
+- a top toolbox with mode buttons
+- select-mode hover and selected overlays
+- element hit-testing inside the iframe
+- selected element state per slide
+- direct-edit controls for text, colors, font size, emphasis, and alignment
+- save calls to the new server endpoint
+- suppression of self-triggered reloads after local saves
+
+**Step 2: Run the targeted test**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js`
+Expected: PASS for the new direct-edit scenario and existing editor UI coverage
+
+**Step 3: Refactor carefully**
+
+Refine helper functions in `src/editor/editor.html` only after the test passes. Keep bbox behavior stable and avoid expanding the feature beyond the approved scope.
+
+### Task 4: Verify regression coverage for editor flows
+
+**Files:**
+- Modify: `tests/editor/editor-concurrency.e2e.test.js` only if direct-edit changes affect shared server behavior
+- Modify: `tests/editor/editor-codex-edit.test.js` only if new pure helpers are added there
+
+**Step 1: Run focused editor test suite**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js tests/editor/editor-concurrency.e2e.test.js tests/editor/editor-codex-edit.test.js`
+Expected: PASS
+
+**Step 2: Review against the approved scope**
+
+Confirm the implementation does all of the following and no more:
+- bbox remains the default mode
+- object select requires explicit mode switch
+- immediate edits are limited to the approved styling controls
+- no layout move/resize behavior was added
+
+**Step 3: Commit**
+
+```bash
+git add src/editor/editor.html scripts/editor-server.js tests/editor/editor-ui.e2e.test.js
+git commit -m "feat: add direct object editing to slide editor"
+```

--- a/docs/plans/2026-03-06-editor-toolbar-popover-redesign-design.md
+++ b/docs/plans/2026-03-06-editor-toolbar-popover-redesign-design.md
@@ -1,0 +1,155 @@
+# Editor Toolbar Popover Redesign Design
+
+## Goal
+
+Redesign the slide editor toolbar so it behaves like a compact icon tool strip instead of a shifting inspector form. The bbox workflow remains available, but the primary controls move into a stable top toolbar with mode-specific actions.
+
+## Scope
+
+In scope:
+- remove the right-side chat/log inspector from the editor UI
+- keep bbox drawing as an explicit mode
+- keep model selection in bbox mode
+- add a single-line Codex prompt input in bbox mode
+- redesign object editing around icon buttons and contextual popovers
+- keep unavailable object-edit actions visible but disabled
+- stop showing selected DOM tag names or object labels in the toolbar
+
+Out of scope:
+- restoring prompt history or execution logs in another panel
+- layout move/resize/reposition editing
+- arbitrary CSS editing
+- multi-object editing
+- object hierarchy inspection
+
+## Problems With The Current Toolbar
+
+- The toolbar exposes full inline form controls all the time, so width changes when the selected object text changes.
+- The selected object chip and inline input groups compete for horizontal space.
+- The right sidebar duplicates the top-level editing flow and adds visual weight without being central to the bbox workflow.
+- The current direct-edit UI feels like an inspector, not like a fast editing tool.
+
+## Recommended Approach
+
+Use a fixed-height icon toolbar with two mutually exclusive modes:
+
+1. `BBox` mode
+   - The toolbar shows:
+     - `BBox` mode button
+     - `Select` mode button
+     - one-line prompt input
+     - model selector
+     - send button
+   - No direct object-edit controls are shown.
+
+2. `Select` mode
+   - The toolbar shows:
+     - `BBox` mode button
+     - `Select` mode button
+     - text edit button
+     - text color button
+     - background color button
+     - font size button
+     - bold toggle
+     - italic toggle
+     - underline toggle
+     - strikethrough toggle
+     - align left / center / right toggles
+   - Text, colors, and size open compact popovers.
+   - Toggle-style actions apply immediately.
+   - Unsupported actions remain in place but disabled.
+
+This keeps the toolbar frame stable while letting the content inside it change only by mode, not by object text length.
+
+## Layout
+
+- Keep the existing navigation bar at the top.
+- Place the toolbar directly below navigation, above the slide stage.
+- Remove the entire right sidebar from the layout.
+- Let the slide stage consume the reclaimed horizontal width.
+- Keep the status bar at the bottom.
+
+Toolbar composition:
+- Left cluster: mode switcher
+- Center/right cluster in bbox mode: prompt input, model select, send
+- Center/right cluster in select mode: icon buttons with separators
+
+The toolbar height stays fixed. Popovers render anchored below the clicked icon and do not resize the toolbar itself.
+
+## Interaction Model
+
+### BBox Mode
+
+- Default mode remains bbox drawing.
+- Dragging on the slide creates red pending boxes as before.
+- The prompt input becomes the primary Codex entry point.
+- `Cmd/Ctrl+Enter` should still submit when the prompt input is focused.
+
+### Select Mode
+
+- Clicking an object selects it.
+- Hover and selected outlines remain over the iframe.
+- Buttons are enabled or disabled based on the currently selected element.
+- No selected object chip is shown.
+
+### Popovers
+
+- Only one popover may be open at a time.
+- Clicking the active icon toggles its popover closed.
+- Clicking outside the toolbar or popover closes the open popover.
+- Switching tool mode closes any open popover.
+- Changing slides clears popovers and selection state.
+
+## Data Flow
+
+### BBox Flow
+
+1. User draws or reruns bbox selections.
+2. User enters a short prompt in the toolbar input.
+3. User picks the model from the toolbar selector.
+4. Client submits the same payload to the existing Codex run path.
+
+### Select Flow
+
+1. User switches to select mode.
+2. Client hit-tests the iframe DOM and stores the selected object XPath.
+3. Toolbar computes capability flags for the selected element.
+4. User opens a popover or presses a toggle button.
+5. Client updates inline style or text content in the iframe DOM.
+6. Client persists the edited slide HTML through the existing save endpoint added for issue #10.
+
+## Capability Rules
+
+- `Text`: enabled only for direct text tags already supported by the first version (`p`, `h1`-`h6`, `li`) and simple editable text nodes.
+- `Text color`: enabled when a selected element can receive text styling.
+- `Background`: enabled for selected block elements where background color is meaningful.
+- `Size`: enabled for text-capable elements.
+- `Bold`, `Italic`, `Underline`, `Strikethrough`: enabled for text-capable elements.
+- `Align`: enabled for text-capable elements or containers whose text alignment is already editable in the current model.
+
+When capability is ambiguous, prefer disabling the control instead of applying a potentially destructive edit.
+
+## Error Handling
+
+- No selected object: all select-mode action buttons are disabled.
+- Save failure: preserve the local visual change, show the failure in the status bar, and keep the object selected.
+- Popover submit failure: close nothing automatically; keep the current input visible so the user can retry or cancel.
+- Slide reload that invalidates the selection: clear selection and disable controls.
+
+## Testing Strategy
+
+- Update editor e2e coverage to assert:
+  - the sidebar is gone
+  - the toolbar remains visible above the stage
+  - bbox mode shows prompt input, model select, and send
+  - select mode shows the icon toolset
+  - disabled controls stay rendered without shifting layout
+  - text/color/size popovers open and apply edits
+  - bbox workflow still works after switching modes
+- Keep the existing direct-edit persistence checks by verifying saved slide HTML on disk.
+
+## Risks
+
+- Removing the sidebar changes several selectors and layout assumptions in the test suite.
+- Popover focus management can introduce stale open states if slide reload and pointer events race.
+- Reusing the existing direct-edit model helps limit scope, but some controls may need stricter capability checks to avoid enabling invalid edits.

--- a/docs/plans/2026-03-06-editor-toolbar-popover-redesign.md
+++ b/docs/plans/2026-03-06-editor-toolbar-popover-redesign.md
@@ -1,0 +1,149 @@
+# Editor Toolbar Popover Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the current inspector-like editor UI with a fixed icon toolbar that uses mode-specific controls, removes the right sidebar, keeps bbox prompting inline, and preserves direct object editing through popovers.
+
+**Architecture:** Rework the editor layout so the slide stage occupies the main canvas width while the toolbar becomes the single primary control surface. Keep bbox drawing and direct object editing in the same client, but split the toolbar into `bbox` and `select` presentations, with contextual popovers for text, colors, and size.
+
+**Tech Stack:** HTML/CSS/vanilla JS in `src/editor/editor.html`, Node.js editor server in `scripts/editor-server.js`, Node Playwright e2e tests in `tests/editor/editor-ui.e2e.test.js`
+
+---
+
+### Task 1: Capture the redesigned UI with failing editor tests
+
+**Files:**
+- Modify: `tests/editor/editor-ui.e2e.test.js`
+
+**Step 1: Write the failing test**
+
+Add or update e2e coverage to assert:
+- the right sidebar no longer renders
+- bbox mode renders a single-line prompt input, model selector, and send button in the top toolbar
+- select mode renders stable icon controls instead of the old inline form groups
+- a disabled select control remains visible when no compatible object is selected
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js`
+Expected: FAIL because the old sidebar and toolbar layout are still present
+
+**Step 3: Tighten selectors if needed**
+
+Make the failure point specific to the redesign, not to unrelated editor timing.
+
+### Task 2: Add failing coverage for popover-based object editing
+
+**Files:**
+- Modify: `tests/editor/editor-ui.e2e.test.js`
+
+**Step 1: Extend the failing test**
+
+Add assertions that:
+- select mode text button opens a popover
+- text edits submitted from the popover update the slide file
+- size or color popovers also apply edits without requiring the old always-visible inputs
+
+**Step 2: Run test to verify it still fails for the new behavior**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js`
+Expected: FAIL because the popover UI does not exist yet
+
+### Task 3: Replace the layout and remove the sidebar
+
+**Files:**
+- Modify: `src/editor/editor.html`
+
+**Step 1: Write minimal layout changes**
+
+Refactor the editor shell so:
+- the sidebar markup is removed
+- the slide panel becomes the main workspace
+- the toolbar is the only top-level editing surface
+- the status bar remains
+
+**Step 2: Run the targeted test**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js`
+Expected: FAIL later, after layout assertions pass but popover/select behavior is still missing
+
+### Task 4: Implement mode-specific toolbar content
+
+**Files:**
+- Modify: `src/editor/editor.html`
+
+**Step 1: Write minimal bbox toolbar implementation**
+
+Add:
+- compact mode buttons
+- inline prompt input for bbox mode
+- preserved model selector
+- inline send button
+
+Keep the existing bbox run flow and keyboard shortcut behavior intact.
+
+**Step 2: Write minimal select toolbar implementation**
+
+Add:
+- stable icon button strip
+- disabled-state capability rendering
+- removal of selected object chip
+
+**Step 3: Run the targeted test**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js`
+Expected: FAIL later on missing popover editing
+
+### Task 5: Implement popovers and wire direct-edit actions
+
+**Files:**
+- Modify: `src/editor/editor.html`
+
+**Step 1: Add popover state and rendering**
+
+Implement one-open-at-a-time popovers for:
+- text edit
+- text color
+- background color
+- font size
+
+Use compact anchored overlays that do not resize the toolbar.
+
+**Step 2: Connect direct-edit actions**
+
+Reuse the existing direct-edit and save pipeline so popover submissions:
+- update the selected iframe element
+- persist the new HTML through the save endpoint
+- keep bbox mode behavior untouched
+
+**Step 3: Run the targeted test**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js`
+Expected: PASS for redesigned toolbar coverage
+
+### Task 6: Verify regression coverage and commit
+
+**Files:**
+- Modify: `tests/editor/editor-concurrency.e2e.test.js` only if timing/layout changes require selector updates
+- Modify: `tests/editor/editor-codex-edit.test.js` only if helper behavior changes require new coverage
+
+**Step 1: Run focused editor verification**
+
+Run: `node --test tests/editor/editor-ui.e2e.test.js tests/editor/editor-concurrency.e2e.test.js tests/editor/editor-codex-edit.test.js`
+Expected: PASS
+
+**Step 2: Review scope**
+
+Confirm the redesign does all of the following:
+- removes the right sidebar
+- keeps model selection in bbox mode
+- keeps bbox as the default mode
+- uses popovers for text/color/size editing
+- shows unavailable actions as disabled instead of hiding them
+
+**Step 3: Commit**
+
+```bash
+git add src/editor/editor.html tests/editor/editor-ui.e2e.test.js docs/plans/2026-03-06-editor-toolbar-popover-redesign-design.md docs/plans/2026-03-06-editor-toolbar-popover-redesign.md
+git commit -m "feat: redesign editor toolbar for bbox and direct edit"
+```

--- a/scripts/editor-server.js
+++ b/scripts/editor-server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readdir, readFile, mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { readdir, readFile, writeFile, mkdtemp, rm, mkdir } from 'node:fs/promises';
 import { watch as fsWatch } from 'node:fs';
 import { basename, dirname, join, resolve, relative, sep } from 'node:path';
 import { spawn } from 'node:child_process';
@@ -165,6 +165,21 @@ async function listSlideFiles(slidesDirectory) {
       const numB = Number.parseInt(b.match(/\d+/)?.[0] ?? '0', 10);
       return numA - numB || a.localeCompare(b);
     });
+}
+
+function normalizeSlideFilename(rawSlide, source = '`slide`') {
+  const slide = typeof rawSlide === 'string' ? basename(rawSlide.trim()) : '';
+  if (!slide || !SLIDE_FILE_PATTERN.test(slide)) {
+    throw new Error(`Missing or invalid ${source}.`);
+  }
+  return slide;
+}
+
+function normalizeSlideHtml(rawHtml) {
+  if (typeof rawHtml !== 'string' || rawHtml.trim() === '') {
+    throw new Error('Missing or invalid `html`.');
+  }
+  return rawHtml;
 }
 
 function sanitizeTargets(rawTargets) {
@@ -389,8 +404,10 @@ async function startServer(opts) {
   });
 
   app.get('/slides/:file', async (req, res) => {
-    const file = basename(req.params.file);
-    if (!SLIDE_FILE_PATTERN.test(file)) {
+    let file;
+    try {
+      file = normalizeSlideFilename(req.params.file, 'slide filename');
+    } catch {
       return res.status(400).send('Invalid slide filename');
     }
 
@@ -409,6 +426,57 @@ async function startServer(opts) {
       res.json(files);
     } catch (err) {
       res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.post('/api/slides/:file/save', async (req, res) => {
+    let file;
+    try {
+      file = normalizeSlideFilename(req.params.file, '`slide`');
+    } catch (error) {
+      return res.status(400).json({ error: error.message });
+    }
+
+    const bodySlide = req.body?.slide;
+    if (bodySlide !== undefined) {
+      let normalizedBodySlide;
+      try {
+        normalizedBodySlide = normalizeSlideFilename(bodySlide, '`slide`');
+      } catch (error) {
+        return res.status(400).json({ error: error.message });
+      }
+
+      if (normalizedBodySlide !== file) {
+        return res.status(400).json({ error: '`slide` does not match the requested file.' });
+      }
+    }
+
+    let html;
+    try {
+      html = normalizeSlideHtml(req.body?.html);
+    } catch (error) {
+      return res.status(400).json({ error: error.message });
+    }
+
+    const filePath = join(slidesDirectory, file);
+    try {
+      await readFile(filePath, 'utf-8');
+    } catch {
+      return res.status(404).json({ error: `Slide not found: ${file}` });
+    }
+
+    try {
+      await writeFile(filePath, html, 'utf8');
+      return res.json({
+        success: true,
+        slide: file,
+        bytes: Buffer.byteLength(html, 'utf8'),
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: `Failed to save ${file}: ${error.message}`,
+      });
     }
   });
 

--- a/src/editor/editor.html
+++ b/src/editor/editor.html
@@ -143,10 +143,10 @@
       flex: 1;
       display: flex;
       flex-direction: column;
-      align-items: center;
-      justify-content: center;
+      align-items: stretch;
+      justify-content: flex-start;
       gap: 12px;
-      padding: 24px;
+      padding: 16px 24px 24px;
       min-width: 0;
       overflow: hidden;
       background: linear-gradient(180deg, #0f141b 0%, #0d1218 100%);
@@ -163,6 +163,20 @@
       border-radius: 12px;
       background: rgba(15, 21, 29, 0.92);
       box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
+      position: relative;
+      z-index: 20;
+      align-self: center;
+      flex: 0 0 auto;
+    }
+
+    .slide-stage {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      align-items: flex-start;
+      justify-content: center;
+      overflow: hidden;
+      position: relative;
     }
 
     .tool-mode-group,
@@ -298,7 +312,8 @@
       position: relative;
       width: 960px;
       height: 540px;
-      transform-origin: center center;
+      transform-origin: top center;
+      z-index: 1;
     }
 
     .slide-wrapper iframe {
@@ -1075,16 +1090,18 @@
             </div>
           </div>
         </div>
-        <div class="slide-wrapper" id="slide-wrapper">
-          <button class="clear-overlay-btn" id="btn-clear-bboxes" title="Clear all boxes on current slide">Clear Boxes</button>
-          <iframe id="slide-iframe" sandbox="allow-same-origin allow-scripts" loading="eager"></iframe>
-          <div class="bbox-layer" id="bbox-layer"></div>
-          <div class="object-layer" id="object-layer">
-            <div class="object-outline hover" id="object-hover-box"></div>
-            <div class="object-outline selected" id="object-selected-box"></div>
-          </div>
-          <div class="draw-layer" id="draw-layer">
-            <div class="draw-box" id="draw-box"></div>
+        <div class="slide-stage" id="slide-stage">
+          <div class="slide-wrapper" id="slide-wrapper">
+            <button class="clear-overlay-btn" id="btn-clear-bboxes" title="Clear all boxes on current slide">Clear Boxes</button>
+            <iframe id="slide-iframe" sandbox="allow-same-origin allow-scripts" loading="eager"></iframe>
+            <div class="bbox-layer" id="bbox-layer"></div>
+            <div class="object-layer" id="object-layer">
+              <div class="object-outline hover" id="object-hover-box"></div>
+              <div class="object-outline selected" id="object-selected-box"></div>
+            </div>
+            <div class="draw-layer" id="draw-layer">
+              <div class="draw-box" id="draw-box"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -1188,6 +1205,7 @@
     const slideIframe = $('#slide-iframe');
     const slidePanel = $('#slide-panel');
     const slideToolbox = $('#slide-toolbox');
+    const slideStage = $('#slide-stage');
     const slideWrapper = $('#slide-wrapper');
     const bboxLayer = $('#bbox-layer');
     const objectLayer = $('#object-layer');
@@ -1527,14 +1545,13 @@
     // Slide & bbox rendering
     // -------------------------------------------------------------------------
     function scaleSlide() {
-      const padX = 48;
-      const padY = 48;
-      const toolboxHeight = slideToolbox?.offsetHeight || 0;
-      const availW = slidePanel.clientWidth - padX;
-      const availH = slidePanel.clientHeight - padY - toolboxHeight;
+      const padX = 12;
+      const padY = 12;
+      const availW = slideStage.clientWidth - padX;
+      const availH = slideStage.clientHeight - padY;
       if (availW <= 0 || availH <= 0) return;
 
-      const scale = Math.min(availW / SLIDE_W, availH / SLIDE_H) * 0.95;
+      const scale = Math.min(availW / SLIDE_W, availH / SLIDE_H, 1);
       slideWrapper.style.transform = `scale(${scale})`;
     }
 

--- a/src/editor/editor.html
+++ b/src/editor/editor.html
@@ -142,13 +142,9 @@
     .slide-panel {
       flex: 1;
       display: flex;
-      flex-direction: column;
-      align-items: stretch;
-      justify-content: flex-start;
-      gap: 12px;
-      padding: 16px 24px 24px;
       min-width: 0;
       overflow: hidden;
+      padding: 12px;
       background: linear-gradient(180deg, #0f141b 0%, #0d1218 100%);
     }
 
@@ -173,7 +169,7 @@
       flex: 1;
       min-height: 0;
       display: flex;
-      align-items: flex-start;
+      align-items: center;
       justify-content: center;
       overflow: hidden;
       position: relative;
@@ -1229,12 +1225,258 @@
       white-space: nowrap;
     }
 
-    .selected-object-mini {
+    /* ── Editor sidebar ── */
+    .editor-sidebar {
+      width: 280px;
+      min-width: 280px;
+      border-left: 1px solid var(--border);
+      background: linear-gradient(180deg, #11161d 0%, #0d1218 100%);
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    .sidebar-mode-tabs {
+      display: flex;
+      gap: 2px;
+      padding: 10px 10px 0;
+      flex: 0 0 auto;
+    }
+
+    .sidebar-mode-tab {
+      flex: 1;
+      height: 38px;
+      border: 1px solid #2c3847;
+      background: #18212c;
+      color: #b0bcc9;
+      border-radius: 10px;
+      font-size: 12px;
+      font-family: var(--mono);
+      font-weight: 700;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
       display: inline-flex;
       align-items: center;
+      justify-content: center;
+      gap: 8px;
+    }
+
+    .sidebar-mode-tab .tool-icon {
+      width: 14px;
+      height: 14px;
+    }
+
+    .sidebar-mode-tab:hover { background: #212d3a; }
+
+    .sidebar-mode-tab.active {
+      border-color: #3963a4;
+      background: #1d3355;
+      color: #e8f0fb;
+    }
+
+    .sidebar-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 12px 10px;
+      min-height: 0;
+    }
+
+    .sidebar-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .sidebar-panel[hidden] {
+      display: none !important;
+    }
+
+    .sidebar-section {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .sidebar-label {
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-2);
+      font-family: var(--mono);
+    }
+
+    .sidebar-divider {
+      height: 1px;
+      background: var(--border-soft);
+      margin: 4px 0;
+    }
+
+    .sidebar-textarea {
+      width: 100%;
+      min-height: 68px;
+      border-radius: 10px;
+      border: 1px solid #2e3948;
+      background: #0f141a;
+      color: #e6edf3;
+      font-size: 13px;
+      font-family: var(--sans);
+      padding: 10px 12px;
+      outline: none;
+      resize: vertical;
+      line-height: 1.45;
+    }
+
+    .sidebar-textarea:focus { border-color: #3c4e63; }
+    .sidebar-textarea::placeholder { color: #627183; }
+
+    .editor-sidebar .model-select {
+      width: 100%;
+      min-width: 0;
+      height: 38px;
+      border-radius: 10px;
+    }
+
+    .sidebar-btn {
+      width: 100%;
+      height: 40px;
+      border: none;
+      border-radius: 10px;
+      font-size: 13px;
+      font-family: var(--sans);
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+    }
+
+    .sidebar-btn:disabled { opacity: 0.35; cursor: default; }
+
+    .sidebar-btn-primary {
+      background: linear-gradient(180deg, #2754a7 0%, #1d3f84 100%);
+      color: #dce7f6;
+      border: 1px solid #304f85;
+    }
+
+    .sidebar-btn-primary:hover:not(:disabled) {
+      background: linear-gradient(180deg, #2d63c8 0%, #224a99 100%);
+    }
+
+    .sidebar-btn-primary .btn-send-icon {
+      width: 14px;
+      height: 14px;
+      fill: currentColor;
+    }
+
+    .sidebar-input {
+      flex: 1;
+      min-width: 0;
       height: 34px;
-      max-width: 200px;
+      border-radius: 8px;
+      border: 1px solid #2e3948;
+      background: #0f141a;
+      color: #e6edf3;
+      font-size: 12px;
+      font-family: var(--sans);
       padding: 0 10px;
+      outline: none;
+    }
+
+    .sidebar-input:focus { border-color: #496a94; }
+    .sidebar-input:disabled { opacity: 0.4; cursor: default; }
+
+    .sidebar-number {
+      width: 70px;
+      flex: 0 0 auto;
+      font-family: var(--mono);
+    }
+
+    .sidebar-unit {
+      color: var(--text-2);
+      font-size: 11px;
+      font-family: var(--mono);
+    }
+
+    .sidebar-field-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .sidebar-btn-sm {
+      height: 34px;
+      padding: 0 12px;
+      border-radius: 8px;
+      border: 1px solid #3b82f6;
+      background: #18365d;
+      color: #eff6ff;
+      font-size: 11px;
+      font-family: var(--mono);
+      font-weight: 700;
+      cursor: pointer;
+      flex: 0 0 auto;
+    }
+
+    .sidebar-btn-sm:hover:not(:disabled) { background: #1d4173; }
+    .sidebar-btn-sm:disabled { opacity: 0.35; cursor: default; }
+
+    .sidebar-color-row {
+      display: flex;
+      gap: 8px;
+    }
+
+    .sidebar-color-field {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      cursor: pointer;
+    }
+
+    .sidebar-color-label {
+      font-size: 10px;
+      color: var(--text-2);
+      font-family: var(--mono);
+    }
+
+    .sidebar-color {
+      width: 100%;
+      height: 36px;
+      border-radius: 8px;
+      border: 1px solid #2e3948;
+      background: #111722;
+      cursor: pointer;
+      padding: 3px;
+    }
+
+    .sidebar-color:disabled { opacity: 0.35; cursor: default; }
+
+    .sidebar-icon-grid {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .editor-sidebar .tool-icon-btn {
+      min-width: 38px;
+      height: 38px;
+      border-radius: 10px;
+      padding: 0 8px;
+    }
+
+    .editor-sidebar .tool-icon-btn.tight {
+      min-width: 38px;
+      width: 38px;
+      padding: 0;
+    }
+
+    .sidebar-object-card {
+      display: flex;
+      align-items: center;
+      padding: 8px 10px;
       border-radius: 8px;
       border: 1px solid #2f3c4d;
       background: #111a24;
@@ -1244,41 +1486,31 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      flex: 0 0 auto;
     }
 
-    .selected-object-mini .mini-tag {
+    .sidebar-object-card .mini-tag {
       color: #60a5fa;
       font-weight: 700;
       margin-right: 3px;
-    }
-
-    .toolbar-group-label {
-      color: var(--text-2);
-      font-size: 9px;
-      font-family: var(--mono);
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      flex: 0 0 auto;
-      white-space: nowrap;
-    }
-
-    .color-indicator {
-      position: absolute;
-      bottom: 5px;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 18px;
-      height: 3px;
-      border-radius: 1.5px;
-      pointer-events: none;
     }
 
     .select-empty-hint {
       color: var(--text-2);
       font-size: 12px;
       font-family: var(--mono);
-      padding: 0 4px;
+      padding: 8px 0;
+    }
+
+    .sidebar-hint {
+      flex: 0 0 auto;
+      padding: 8px 12px;
+      border-top: 1px solid var(--border-soft);
+      color: var(--text-2);
+      font-size: 11px;
+      font-family: var(--mono);
+      min-height: 32px;
+      overflow: hidden;
+      text-overflow: ellipsis;
       white-space: nowrap;
     }
 
@@ -1313,139 +1545,6 @@
 
     <div class="main-content">
       <div class="slide-panel" id="slide-panel">
-        <div class="slide-toolbox" id="slide-toolbox">
-          <div class="tool-strip" id="tool-strip">
-            <div class="tool-mode-group">
-              <button type="button" class="tool-mode-btn active" id="tool-mode-draw" aria-pressed="true" title="BBox mode">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M5 5h14v14H5zM9 5v14M15 5v14M5 9h14M5 15h14"/>
-                </svg>
-                <span>BBox</span>
-              </button>
-              <button type="button" class="tool-mode-btn" id="tool-mode-select" aria-pressed="false" title="Select object mode">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="m6 4 11 8-5 1.2L14.6 20l-2.5 1-2.6-6.8L6 15z"/>
-                </svg>
-                <span>Select</span>
-              </button>
-            </div>
-            <div class="toolbar-divider" aria-hidden="true"></div>
-            <div class="bbox-toolbar" id="bbox-toolbar">
-              <span class="bbox-count" id="bbox-count">0 pending · 0 review</span>
-              <div class="prompt-shell">
-                <input id="prompt-input" class="prompt-input" type="text" placeholder="Describe the edit for the selected red bbox">
-              </div>
-              <select id="model-select" class="model-select">
-                <option value="gpt-5.3-codex">gpt-5.3-codex</option>
-                <option value="gpt-5.3-codex-spark">gpt-5.3-codex-spark</option>
-              </select>
-              <button class="btn btn-send" id="btn-send" title="Run Codex" aria-label="Run Codex">
-                <svg class="btn-send-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M3.4 11.2 19.6 4.4c.8-.3 1.7.5 1.4 1.4l-6.8 16.2c-.3.8-1.4.9-1.9.1L9.2 16l-6.1-3.1c-.8-.5-.7-1.6.3-1.7Zm5.1 3.6 3.2 1.6 4.9-11.7-11.7 4.9 3.6 1.8 6.2-3.7c.4-.2.8.1.6.6l-6.8 6.5Z"/>
-                </svg>
-              </button>
-            </div>
-            <div class="select-toolbar" id="select-toolbar" hidden>
-              <span class="selected-object-mini" id="selected-object-mini" style="display:none">
-                <span class="mini-tag" id="mini-tag"></span>
-                <span id="mini-text"></span>
-              </span>
-              <span class="select-empty-hint" id="select-empty-hint">Click an object to select</span>
-              <div class="toolbar-divider" aria-hidden="true"></div>
-              <span class="toolbar-group-label">Edit</span>
-              <button type="button" class="tool-icon-btn" id="select-action-text" title="Edit text">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/>
-                </svg>
-              </button>
-              <button type="button" class="tool-icon-btn" id="select-action-text-color" title="Text color">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="m9 15 3-9 3 9M10.5 11h3"/>
-                </svg>
-                <span class="color-indicator" id="text-color-indicator" style="background:#888"></span>
-              </button>
-              <button type="button" class="tool-icon-btn" id="select-action-bg-color" title="Background color">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="m19 11-8-8-8.6 8.6a2 2 0 0 0 0 2.8l5.2 5.2a2 2 0 0 0 2.8 0L19 11Z"/><path d="m5 2 5 5"/>
-                </svg>
-                <span class="color-indicator" id="bg-color-indicator" style="background:#888"></span>
-              </button>
-              <button type="button" class="tool-icon-btn" id="select-action-size" title="Font size">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M4 7V4h16v3M9 20h6M12 4v16"/>
-                </svg>
-              </button>
-              <div class="toolbar-divider" aria-hidden="true"></div>
-              <span class="toolbar-group-label">Style</span>
-              <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-bold" title="Bold (⌘B)">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M14 12a4 4 0 0 0 0-8H6v8"/><path d="M15 20a4 4 0 0 0 0-8H6v8"/>
-                </svg>
-              </button>
-              <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-italic" title="Italic (⌘I)">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M19 4h-9M14 20H5M15 4 9 20"/>
-                </svg>
-              </button>
-              <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-underline" title="Underline (⌘U)">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M6 4v6a6 6 0 0 0 12 0V4"/><path d="M4 20h16"/>
-                </svg>
-              </button>
-              <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-strike" title="Strikethrough">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><path d="M4 12h16"/>
-                </svg>
-              </button>
-              <div class="toolbar-divider" aria-hidden="true"></div>
-              <span class="toolbar-group-label">Align</span>
-              <button type="button" class="tool-icon-btn align-btn tight" id="align-left" title="Align left">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M21 6H3M15 12H3M17 18H3"/>
-                </svg>
-              </button>
-              <button type="button" class="tool-icon-btn align-btn tight" id="align-center" title="Align center">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M21 6H3M17 12H7M19 18H5"/>
-                </svg>
-              </button>
-              <button type="button" class="tool-icon-btn align-btn tight" id="align-right" title="Align right">
-                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M21 6H3M21 12H9M21 18H7"/>
-                </svg>
-              </button>
-            </div>
-          </div>
-          <div class="tool-popovers tool-popover-layer" id="tool-popover-layer">
-            <section class="editor-popover" id="editor-popover-text" hidden>
-              <label class="popover-field" for="popover-text-input">
-                <span class="popover-label">Text</span>
-                <input id="popover-text-input" class="popover-input" type="text" placeholder="Edit selected text">
-              </label>
-              <button type="button" class="popover-apply-btn" id="popover-apply-text">Apply</button>
-            </section>
-            <section class="editor-popover" id="editor-popover-size" hidden>
-              <label class="popover-field" for="popover-size-input">
-                <span class="popover-label">Size</span>
-                <input id="popover-size-input" class="popover-input popover-number" type="number" min="8" max="180" step="1" value="24">
-              </label>
-              <button type="button" class="popover-apply-btn" id="popover-apply-size">Apply</button>
-            </section>
-            <section class="editor-popover" id="editor-popover-text-color" hidden>
-              <label class="popover-field" for="popover-text-color-input">
-                <span class="popover-label">Text color</span>
-                <input id="popover-text-color-input" class="popover-color" type="color" value="#111111">
-              </label>
-            </section>
-            <section class="editor-popover" id="editor-popover-bg-color" hidden>
-              <label class="popover-field" for="popover-bg-color-input">
-                <span class="popover-label">Background</span>
-                <input id="popover-bg-color-input" class="popover-color" type="color" value="#ffffff">
-              </label>
-            </section>
-          </div>
-          <div class="hint" id="editor-hint">Drag on the slide to add red pending bboxes. Press Enter to run.</div>
-        </div>
         <div class="slide-stage" id="slide-stage">
           <div class="slide-wrapper" id="slide-wrapper">
             <button class="clear-overlay-btn" id="btn-clear-bboxes" title="Clear all boxes on current slide">Clear Boxes</button>
@@ -1461,6 +1560,118 @@
           </div>
         </div>
       </div>
+
+      <aside class="editor-sidebar" id="editor-sidebar">
+        <div class="sidebar-mode-tabs">
+          <button type="button" class="sidebar-mode-tab active" id="tool-mode-draw" aria-pressed="true">
+            <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 5h14v14H5zM9 5v14M15 5v14M5 9h14M5 15h14"/></svg>
+            BBox
+          </button>
+          <button type="button" class="sidebar-mode-tab" id="tool-mode-select" aria-pressed="false">
+            <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m6 4 11 8-5 1.2L14.6 20l-2.5 1-2.6-6.8L6 15z"/></svg>
+            Select
+          </button>
+        </div>
+
+        <div class="sidebar-body" id="sidebar-body">
+          <div class="sidebar-panel" id="bbox-toolbar">
+            <div class="sidebar-section">
+              <span class="sidebar-label" id="bbox-count">0 pending · 0 review</span>
+              <div class="context-chips" id="context-chip-list"></div>
+            </div>
+            <div class="sidebar-section">
+              <span class="sidebar-label">Prompt</span>
+              <textarea id="prompt-input" class="sidebar-textarea" placeholder="Describe the edit for red bboxes..." rows="3"></textarea>
+            </div>
+            <div class="sidebar-section">
+              <span class="sidebar-label">Model</span>
+              <select id="model-select" class="model-select">
+                <option value="gpt-5.3-codex">gpt-5.3-codex</option>
+                <option value="gpt-5.3-codex-spark">gpt-5.3-codex-spark</option>
+              </select>
+            </div>
+            <button class="sidebar-btn sidebar-btn-primary" id="btn-send" title="Run Codex">
+              <svg class="btn-send-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3.4 11.2 19.6 4.4c.8-.3 1.7.5 1.4 1.4l-6.8 16.2c-.3.8-1.4.9-1.9.1L9.2 16l-6.1-3.1c-.8-.5-.7-1.6.3-1.7Zm5.1 3.6 3.2 1.6 4.9-11.7-11.7 4.9 3.6 1.8 6.2-3.7c.4-.2.8.1.6.6l-6.8 6.5Z"/></svg>
+              Run Codex
+            </button>
+          </div>
+
+          <div class="sidebar-panel" id="select-toolbar" hidden>
+            <div class="sidebar-section">
+              <div class="sidebar-object-card" id="selected-object-mini" style="display:none">
+                <span class="mini-tag" id="mini-tag"></span>
+                <span id="mini-text"></span>
+              </div>
+              <span class="select-empty-hint" id="select-empty-hint">Click an object on the slide</span>
+            </div>
+            <div class="sidebar-divider"></div>
+            <div class="sidebar-section">
+              <span class="sidebar-label">Text</span>
+              <div class="sidebar-field-row">
+                <input id="popover-text-input" class="sidebar-input" type="text" placeholder="Edit text...">
+                <button type="button" class="sidebar-btn-sm" id="popover-apply-text">Set</button>
+              </div>
+            </div>
+            <div class="sidebar-section">
+              <span class="sidebar-label">Color</span>
+              <div class="sidebar-color-row">
+                <label class="sidebar-color-field">
+                  <span class="sidebar-color-label">Text</span>
+                  <input id="popover-text-color-input" class="sidebar-color" type="color" value="#111111">
+                </label>
+                <label class="sidebar-color-field">
+                  <span class="sidebar-color-label">Bg</span>
+                  <input id="popover-bg-color-input" class="sidebar-color" type="color" value="#ffffff">
+                </label>
+              </div>
+            </div>
+            <div class="sidebar-section">
+              <span class="sidebar-label">Size</span>
+              <div class="sidebar-field-row">
+                <input id="popover-size-input" class="sidebar-input sidebar-number" type="number" min="8" max="180" step="1" value="24">
+                <span class="sidebar-unit">px</span>
+                <button type="button" class="sidebar-btn-sm" id="popover-apply-size">Set</button>
+              </div>
+            </div>
+            <div class="sidebar-divider"></div>
+            <div class="sidebar-section">
+              <span class="sidebar-label">Style</span>
+              <div class="sidebar-icon-grid">
+                <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-bold" title="Bold (⌘B)">
+                  <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 12a4 4 0 0 0 0-8H6v8"/><path d="M15 20a4 4 0 0 0 0-8H6v8"/></svg>
+                </button>
+                <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-italic" title="Italic (⌘I)">
+                  <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 4h-9M14 20H5M15 4 9 20"/></svg>
+                </button>
+                <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-underline" title="Underline (⌘U)">
+                  <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4v6a6 6 0 0 0 12 0V4"/><path d="M4 20h16"/></svg>
+                </button>
+                <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-strike" title="Strikethrough">
+                  <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><path d="M4 12h16"/></svg>
+                </button>
+              </div>
+            </div>
+            <div class="sidebar-section">
+              <span class="sidebar-label">Align</span>
+              <div class="sidebar-icon-grid">
+                <button type="button" class="tool-icon-btn align-btn tight" id="align-left" title="Align left">
+                  <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 6H3M15 12H3M17 18H3"/></svg>
+                </button>
+                <button type="button" class="tool-icon-btn align-btn tight" id="align-center" title="Align center">
+                  <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 6H3M17 12H7M19 18H5"/></svg>
+                </button>
+                <button type="button" class="tool-icon-btn align-btn tight" id="align-right" title="Align right">
+                  <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 6H3M21 12H9M21 18H7"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="sidebar-hint" id="editor-hint">
+          Drag on the slide to add red bboxes. Enter to run.
+        </div>
+      </aside>
     </div>
 
     <div class="status-bar">
@@ -1501,7 +1712,6 @@
     let defaultModel = DEFAULT_MODELS[0];
     let selectedModel = defaultModel;
     let toolMode = TOOL_MODE_DRAW;
-    let openPopover = '';
     let hoveredObjectXPath = '';
 
     const directSaveStateBySlide = new Map();
@@ -1518,7 +1728,6 @@
 
     const slideIframe = $('#slide-iframe');
     const slidePanel = $('#slide-panel');
-    const slideToolbox = $('#slide-toolbox');
     const slideStage = $('#slide-stage');
     const slideWrapper = $('#slide-wrapper');
     const bboxLayer = $('#bbox-layer');
@@ -1531,10 +1740,7 @@
     const toolModeSelectBtn = $('#tool-mode-select');
     const bboxToolbar = $('#bbox-toolbar');
     const selectToolbar = $('#select-toolbar');
-    const selectActionText = $('#select-action-text');
-    const selectActionTextColor = $('#select-action-text-color');
-    const selectActionBgColor = $('#select-action-bg-color');
-    const selectActionSize = $('#select-action-size');
+    // Inline sidebar inputs (no popover trigger buttons needed)
     const toggleBold = $('#toggle-bold');
     const toggleItalic = $('#toggle-italic');
     const toggleUnderline = $('#toggle-underline');
@@ -1542,17 +1748,10 @@
     const alignLeft = $('#align-left');
     const alignCenter = $('#align-center');
     const alignRight = $('#align-right');
-    const toolPopoverLayer = $('#tool-popover-layer');
-    const popoverText = $('#editor-popover-text');
     const popoverTextInput = $('#popover-text-input');
     const popoverApplyText = $('#popover-apply-text');
-    const popoverTextColor = $('#editor-popover-text-color');
     const popoverTextColorInput = $('#popover-text-color-input');
-
-    const popoverBgColor = $('#editor-popover-bg-color');
     const popoverBgColorInput = $('#popover-bg-color-input');
-
-    const popoverSize = $('#editor-popover-size');
     const popoverSizeInput = $('#popover-size-input');
     const popoverApplySize = $('#popover-apply-size');
 
@@ -1569,8 +1768,6 @@
     const miniTag = $('#mini-tag');
     const miniText = $('#mini-text');
     const selectEmptyHint = $('#select-empty-hint');
-    const textColorIndicator = $('#text-color-indicator');
-    const bgColorIndicator = $('#bg-color-indicator');
 
     const statusDot = $('#status-dot');
     const statusConn = $('#status-connection');
@@ -2237,102 +2434,13 @@
       };
     }
 
-    function getPopoverElement(popoverId) {
-      if (popoverId === POPOVER_TEXT) return popoverText;
-      if (popoverId === POPOVER_TEXT_COLOR) return popoverTextColor;
-      if (popoverId === POPOVER_BG_COLOR) return popoverBgColor;
-      if (popoverId === POPOVER_SIZE) return popoverSize;
-      return null;
-    }
-
-    function getPopoverTrigger(popoverId) {
-      if (popoverId === POPOVER_TEXT) return selectActionText;
-      if (popoverId === POPOVER_TEXT_COLOR) return selectActionTextColor;
-      if (popoverId === POPOVER_BG_COLOR) return selectActionBgColor;
-      if (popoverId === POPOVER_SIZE) return selectActionSize;
-      return null;
-    }
-
-    function syncPopoverInputs(snapshot) {
-      popoverTextInput.value = snapshot?.textValue || '';
+    function syncInlineInputs(snapshot) {
+      if (!document.activeElement || !document.activeElement.closest?.('#select-toolbar')) {
+        popoverTextInput.value = snapshot?.textValue || '';
+        popoverSizeInput.value = String(snapshot?.fontSize || 24);
+      }
       popoverTextColorInput.value = snapshot?.textColor || '#111111';
       popoverBgColorInput.value = snapshot?.backgroundColor || '#ffffff';
-      popoverSizeInput.value = String(snapshot?.fontSize || 24);
-    }
-
-    function hidePopover() {
-      openPopover = '';
-      [popoverText, popoverTextColor, popoverBgColor, popoverSize].forEach((popover) => {
-        if (!popover) return;
-        popover.hidden = true;
-      });
-      setToggleActive(selectActionText, false);
-      setToggleActive(selectActionTextColor, false);
-      setToggleActive(selectActionBgColor, false);
-      setToggleActive(selectActionSize, false);
-    }
-
-    function positionPopover(popover, trigger) {
-      if (!popover || !trigger || !toolPopoverLayer) return;
-      const layerRect = toolPopoverLayer.getBoundingClientRect();
-      const triggerRect = trigger.getBoundingClientRect();
-      popover.hidden = false;
-      popover.style.visibility = 'hidden';
-      popover.style.left = '0px';
-      popover.style.top = '0px';
-
-      const popRect = popover.getBoundingClientRect();
-      const maxLeft = Math.max(12, layerRect.width - popRect.width - 12);
-      const left = clamp(
-        Math.round(triggerRect.left - layerRect.left + (triggerRect.width - popRect.width) / 2),
-        12,
-        maxLeft,
-      );
-      const top = Math.max(8, Math.round(triggerRect.bottom - layerRect.top + 10));
-
-      popover.style.left = `${left}px`;
-      popover.style.top = `${top}px`;
-      popover.style.visibility = '';
-    }
-
-    function togglePopover(popoverId) {
-      const selected = toolMode === TOOL_MODE_SELECT ? getSelectedObjectElement() : null;
-      const capabilities = getSelectedObjectCapabilities(selected);
-      const enabled = (
-        (popoverId === POPOVER_TEXT && capabilities.textEditable)
-        || (popoverId === POPOVER_TEXT_COLOR && capabilities.textColorEditable)
-        || (popoverId === POPOVER_BG_COLOR && capabilities.backgroundEditable)
-        || (popoverId === POPOVER_SIZE && capabilities.sizeEditable)
-      );
-
-      if (!enabled) return;
-      if (openPopover === popoverId) {
-        hidePopover();
-        return;
-      }
-
-      const snapshot = selected ? readSelectedObjectStyleState(selected) : null;
-      syncPopoverInputs(snapshot);
-      hidePopover();
-      openPopover = popoverId;
-
-      const popover = getPopoverElement(popoverId);
-      const trigger = getPopoverTrigger(popoverId);
-      if (!popover || !trigger) return;
-
-      positionPopover(popover, trigger);
-      setToggleActive(trigger, true);
-      if (popoverId === POPOVER_TEXT) {
-        popoverTextInput.focus();
-        popoverTextInput.select();
-      } else if (popoverId === POPOVER_TEXT_COLOR) {
-        popoverTextColorInput.focus();
-      } else if (popoverId === POPOVER_BG_COLOR) {
-        popoverBgColorInput.focus();
-      } else if (popoverId === POPOVER_SIZE) {
-        popoverSizeInput.focus();
-        popoverSizeInput.select();
-      }
     }
 
     function updateObjectEditorControls() {
@@ -2362,17 +2470,13 @@
         }
       }
 
-      if (textColorIndicator) {
-        textColorIndicator.style.background = snapshot?.textColor || '#888';
-      }
-      if (bgColorIndicator) {
-        bgColorIndicator.style.background = snapshot?.backgroundColor || '#888';
-      }
+      popoverTextInput.disabled = !capabilities.textEditable;
+      popoverApplyText.disabled = !capabilities.textEditable;
+      popoverTextColorInput.disabled = !capabilities.textColorEditable;
+      popoverBgColorInput.disabled = !capabilities.backgroundEditable;
+      popoverSizeInput.disabled = !capabilities.sizeEditable;
+      popoverApplySize.disabled = !capabilities.sizeEditable;
 
-      setControlEnabled(selectActionText, capabilities.textEditable);
-      setControlEnabled(selectActionTextColor, capabilities.textColorEditable);
-      setControlEnabled(selectActionBgColor, capabilities.backgroundEditable);
-      setControlEnabled(selectActionSize, capabilities.sizeEditable);
       setControlEnabled(toggleBold, capabilities.emphasisEditable);
       setControlEnabled(toggleItalic, capabilities.emphasisEditable);
       setControlEnabled(toggleUnderline, capabilities.emphasisEditable);
@@ -2389,23 +2493,7 @@
       setToggleActive(alignCenter, capabilities.alignEditable && snapshot?.textAlign === 'center');
       setToggleActive(alignRight, capabilities.alignEditable && (snapshot?.textAlign === 'right' || snapshot?.textAlign === 'end'));
 
-      if (!selected) {
-        syncPopoverInputs(null);
-        hidePopover();
-        return;
-      }
-
-      syncPopoverInputs(snapshot);
-      if (openPopover) {
-        const popover = getPopoverElement(openPopover);
-        const trigger = getPopoverTrigger(openPopover);
-        if (popover && trigger && !trigger.disabled) {
-          positionPopover(popover, trigger);
-          setToggleActive(trigger, true);
-        } else {
-          hidePopover();
-        }
-      }
+      syncInlineInputs(snapshot);
     }
 
     function renderObjectSelection() {
@@ -2429,9 +2517,8 @@
       toolModeDrawBtn.setAttribute('aria-pressed', isDraw ? 'true' : 'false');
       toolModeSelectBtn.setAttribute('aria-pressed', !isDraw ? 'true' : 'false');
       editorHint.textContent = isDraw
-        ? 'Drag on the slide to add red pending bboxes. Press Enter or Cmd/Ctrl+Enter to run.'
-        : 'Click an object to edit. Shortcuts: \u2318B bold \u00b7 \u2318I italic \u00b7 \u2318U underline';
-      hidePopover();
+        ? 'Drag on the slide to add red bboxes. Cmd/Ctrl+Enter to run.'
+        : 'Click an object to edit. \u2318B bold \u00b7 \u2318I italic \u00b7 \u2318U underline';
       renderBboxes();
       renderObjectSelection();
       updateObjectEditorControls();
@@ -2445,9 +2532,6 @@
       drawBox.style.display = 'none';
       if (toolMode !== TOOL_MODE_SELECT) {
         hoveredObjectXPath = '';
-      }
-      if (toolMode !== TOOL_MODE_SELECT) {
-        hidePopover();
       }
       updateToolModeUI();
       setStatus(toolMode === TOOL_MODE_SELECT ? 'Select mode enabled.' : 'BBox draw mode enabled.');
@@ -2995,40 +3079,20 @@
       updateSendState();
     });
 
-    selectActionText.addEventListener('click', () => {
-      togglePopover(POPOVER_TEXT);
-    });
-
-    selectActionTextColor.addEventListener('click', () => {
-      togglePopover(POPOVER_TEXT_COLOR);
-    });
-
-    selectActionBgColor.addEventListener('click', () => {
-      togglePopover(POPOVER_BG_COLOR);
-    });
-
-    selectActionSize.addEventListener('click', () => {
-      togglePopover(POPOVER_SIZE);
-    });
-
     popoverApplyText.addEventListener('click', () => {
-      if (selectActionText.disabled) return;
+      if (popoverApplyText.disabled) return;
       mutateSelectedObject((el) => {
         el.textContent = popoverTextInput.value;
       }, 'Object text updated and saved.', { delay: 120 });
-      hidePopover();
     });
 
     popoverApplySize.addEventListener('click', () => {
-      if (selectActionSize.disabled) return;
+      if (popoverApplySize.disabled) return;
       const size = clamp(Number.parseInt(popoverSizeInput.value || '24', 10) || 24, 8, 180);
       mutateSelectedObject((el) => {
         el.style.fontSize = `${size}px`;
       }, 'Object font size updated and saved.');
-      hidePopover();
     });
-
-    // Color popovers apply in real-time via input event (no Apply button)
 
     popoverTextInput.addEventListener('keydown', (event) => {
       if (event.key === 'Enter') {
@@ -3047,14 +3111,14 @@
     });
 
     popoverTextColorInput.addEventListener('input', () => {
-      if (selectActionTextColor.disabled) return;
+      if (popoverTextColorInput.disabled) return;
       mutateSelectedObject((el) => {
         el.style.color = popoverTextColorInput.value;
       }, 'Text color updated.', { delay: 300 });
     });
 
     popoverBgColorInput.addEventListener('input', () => {
-      if (selectActionBgColor.disabled) return;
+      if (popoverBgColorInput.disabled) return;
       mutateSelectedObject((el) => {
         el.style.backgroundColor = popoverBgColorInput.value;
       }, 'Background color updated.', { delay: 300 });
@@ -3116,17 +3180,14 @@
         if (key === 'u') { event.preventDefault(); if (!toggleUnderline.disabled) toggleUnderline.click(); return; }
       }
 
-      if (
-        ((event.ctrlKey || event.metaKey) && event.key === 'Enter')
-        || (inPromptField && event.key === 'Enter')
-      ) {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
         event.preventDefault();
         applyChanges();
         return;
       }
 
       if (event.key === 'Escape') {
-        hidePopover();
+        if (document.activeElement) document.activeElement.blur();
         return;
       }
 
@@ -3157,12 +3218,7 @@
       updateSendState();
     });
 
-    document.addEventListener('mousedown', (event) => {
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-      if (target.closest('#slide-toolbox') || target.closest('#tool-popover-layer')) return;
-      hidePopover();
-    });
+    // No popover dismiss needed — controls are inline in sidebar
 
     // -------------------------------------------------------------------------
     // Init

--- a/src/editor/editor.html
+++ b/src/editor/editor.html
@@ -142,12 +142,156 @@
     .slide-panel {
       flex: 1;
       display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: center;
+      gap: 12px;
       padding: 24px;
       min-width: 0;
       overflow: hidden;
       background: linear-gradient(180deg, #0f141b 0%, #0d1218 100%);
+    }
+
+    .slide-toolbox {
+      width: min(100%, 996px);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+      padding: 10px 12px;
+      border: 1px solid #293444;
+      border-radius: 12px;
+      background: rgba(15, 21, 29, 0.92);
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
+    }
+
+    .tool-mode-group,
+    .direct-edit-group,
+    .direct-toggle-group,
+    .direct-align-group {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .tool-mode-btn {
+      border: 1px solid #2c3847;
+      background: #18212c;
+      color: #d6e1ec;
+      border-radius: 8px;
+      height: 32px;
+      padding: 0 10px;
+      font-size: 12px;
+      font-family: var(--mono);
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .tool-mode-btn:hover {
+      background: #212d3a;
+    }
+
+    .tool-mode-btn.active {
+      border-color: #3963a4;
+      background: #1d3355;
+      color: #e8f0fb;
+    }
+
+    .selected-object-chip {
+      min-height: 32px;
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      border: 1px solid #2f3c4d;
+      background: #111a24;
+      color: #d9e4ef;
+      padding: 0 10px;
+      font-size: 11px;
+      font-family: var(--mono);
+      max-width: 260px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .selected-object-chip.empty {
+      color: var(--text-2);
+      border-color: #26303b;
+      background: #0f151d;
+    }
+
+    .direct-edit-controls {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .direct-edit-controls[hidden] {
+      display: none !important;
+    }
+
+    .direct-edit-label {
+      color: var(--text-2);
+      font-size: 11px;
+      font-family: var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .direct-input,
+    .direct-number {
+      height: 32px;
+      border-radius: 8px;
+      border: 1px solid #2e3948;
+      background: #0f141a;
+      color: #e6edf3;
+      font-size: 12px;
+      font-family: var(--sans);
+      padding: 0 10px;
+      outline: none;
+    }
+
+    .direct-input:focus,
+    .direct-number:focus {
+      border-color: #496a94;
+    }
+
+    .direct-text-input {
+      width: 180px;
+    }
+
+    .direct-number {
+      width: 74px;
+      font-family: var(--mono);
+    }
+
+    .direct-color {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      border: 1px solid #2e3948;
+      background: #111722;
+      cursor: pointer;
+      padding: 2px;
+    }
+
+    .style-toggle,
+    .align-btn {
+      min-width: 32px;
+      height: 32px;
+      padding: 0 10px;
+      font-weight: 700;
+      font-family: var(--mono);
+    }
+
+    .style-toggle.active,
+    .align-btn.active {
+      border-color: #3b82f6;
+      background: #18365d;
+      color: #eff6ff;
     }
 
     .slide-wrapper {
@@ -175,12 +319,46 @@
       pointer-events: none;
     }
 
+    .bbox-layer.inert .bbox-item {
+      pointer-events: none;
+      opacity: 0.26;
+    }
+
+    .object-layer {
+      position: absolute;
+      inset: 0;
+      z-index: 10;
+      pointer-events: none;
+    }
+
+    .object-outline {
+      position: absolute;
+      display: none;
+      border-radius: 4px;
+      pointer-events: none;
+    }
+
+    .object-outline.hover {
+      border: 2px dashed rgba(96, 165, 250, 0.95);
+      background: rgba(96, 165, 250, 0.08);
+    }
+
+    .object-outline.selected {
+      border: 2px solid #60a5fa;
+      background: rgba(59, 130, 246, 0.14);
+      box-shadow: 0 0 0 2px rgba(191, 219, 254, 0.22);
+    }
+
     .draw-layer {
       position: absolute;
       inset: 0;
       z-index: 8;
       pointer-events: auto;
       cursor: crosshair;
+    }
+
+    .mode-select .draw-layer {
+      cursor: pointer;
     }
 
     .draw-box {
@@ -822,6 +1000,12 @@
         width: 390px;
         min-width: 300px;
       }
+      .slide-toolbox {
+        justify-content: flex-start;
+      }
+      .selected-object-chip {
+        max-width: 100%;
+      }
       .tool-row {
         flex-wrap: wrap;
       }
@@ -855,10 +1039,50 @@
 
     <div class="main-content">
       <div class="slide-panel" id="slide-panel">
+        <div class="slide-toolbox" id="slide-toolbox">
+          <div class="tool-mode-group">
+            <button type="button" class="tool-mode-btn active" id="tool-mode-draw" aria-pressed="true">Draw Boxes</button>
+            <button type="button" class="tool-mode-btn" id="tool-mode-select" aria-pressed="false">Select Object</button>
+          </div>
+          <div class="selected-object-chip empty" id="selected-object-chip">No object selected</div>
+          <div class="direct-edit-controls" id="direct-edit-controls" hidden>
+            <label class="direct-edit-group" for="object-text-input">
+              <span class="direct-edit-label">Text</span>
+              <input id="object-text-input" class="direct-input direct-text-input" type="text" placeholder="Selected text">
+            </label>
+            <label class="direct-edit-group" for="object-text-color">
+              <span class="direct-edit-label">Text</span>
+              <input id="object-text-color" class="direct-color" type="color" value="#111111" title="Text color">
+            </label>
+            <label class="direct-edit-group" for="object-bg-color">
+              <span class="direct-edit-label">Bg</span>
+              <input id="object-bg-color" class="direct-color" type="color" value="#ffffff" title="Background color">
+            </label>
+            <label class="direct-edit-group" for="object-font-size">
+              <span class="direct-edit-label">Size</span>
+              <input id="object-font-size" class="direct-number" type="number" min="8" max="180" step="1" value="24">
+            </label>
+            <div class="direct-toggle-group">
+              <button type="button" class="tool-mode-btn style-toggle" id="toggle-bold" title="Bold">B</button>
+              <button type="button" class="tool-mode-btn style-toggle" id="toggle-italic" title="Italic">I</button>
+              <button type="button" class="tool-mode-btn style-toggle" id="toggle-underline" title="Underline">U</button>
+              <button type="button" class="tool-mode-btn style-toggle" id="toggle-strike" title="Strikethrough">S</button>
+            </div>
+            <div class="direct-align-group">
+              <button type="button" class="tool-mode-btn align-btn" id="align-left" title="Align left">L</button>
+              <button type="button" class="tool-mode-btn align-btn" id="align-center" title="Align center">C</button>
+              <button type="button" class="tool-mode-btn align-btn" id="align-right" title="Align right">R</button>
+            </div>
+          </div>
+        </div>
         <div class="slide-wrapper" id="slide-wrapper">
           <button class="clear-overlay-btn" id="btn-clear-bboxes" title="Clear all boxes on current slide">Clear Boxes</button>
           <iframe id="slide-iframe" sandbox="allow-same-origin allow-scripts" loading="eager"></iframe>
           <div class="bbox-layer" id="bbox-layer"></div>
+          <div class="object-layer" id="object-layer">
+            <div class="object-outline hover" id="object-hover-box"></div>
+            <div class="object-outline selected" id="object-selected-box"></div>
+          </div>
           <div class="draw-layer" id="draw-layer">
             <div class="draw-box" id="draw-box"></div>
           </div>
@@ -883,7 +1107,7 @@
               <div class="context-chips" id="context-chip-list"></div>
               <span class="bbox-count" id="bbox-count">0 pending · 0 review</span>
             </div>
-            <div class="hint">Drag on the slide to add red pending bboxes. Cmd/Ctrl+Enter to run.</div>
+            <div class="hint" id="editor-hint">Drag on the slide to add red pending bboxes. Cmd/Ctrl+Enter to run.</div>
             <div class="prompt-shell">
               <textarea id="prompt-input" class="prompt-input" placeholder="Describe the edit for this slide..."></textarea>
               <div class="prompt-toolbar">
@@ -937,10 +1161,20 @@
 
     const SLIDE_W = 960;
     const SLIDE_H = 540;
+    const TOOL_MODE_DRAW = 'draw';
+    const TOOL_MODE_SELECT = 'select';
     const DEFAULT_MODELS = ['gpt-5.3-codex', 'gpt-5.3-codex-spark'];
+    const DIRECT_TEXT_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
+    const NON_SELECTABLE_TAGS = new Set(['html', 'head', 'body', 'script', 'style', 'link', 'meta', 'noscript']);
     let availableModels = DEFAULT_MODELS.slice();
     let defaultModel = DEFAULT_MODELS[0];
     let selectedModel = defaultModel;
+    let toolMode = TOOL_MODE_DRAW;
+    let hoveredObjectXPath = '';
+    let syncingDirectControls = false;
+
+    const directSaveStateBySlide = new Map();
+    const localFileUpdateBySlide = new Map();
 
     // -------------------------------------------------------------------------
     // DOM refs
@@ -953,10 +1187,29 @@
 
     const slideIframe = $('#slide-iframe');
     const slidePanel = $('#slide-panel');
+    const slideToolbox = $('#slide-toolbox');
     const slideWrapper = $('#slide-wrapper');
     const bboxLayer = $('#bbox-layer');
+    const objectLayer = $('#object-layer');
+    const objectHoverBox = $('#object-hover-box');
+    const objectSelectedBox = $('#object-selected-box');
     const drawLayer = $('#draw-layer');
     const drawBox = $('#draw-box');
+    const toolModeDrawBtn = $('#tool-mode-draw');
+    const toolModeSelectBtn = $('#tool-mode-select');
+    const selectedObjectChip = $('#selected-object-chip');
+    const directEditControls = $('#direct-edit-controls');
+    const objectTextInput = $('#object-text-input');
+    const objectTextColor = $('#object-text-color');
+    const objectBgColor = $('#object-bg-color');
+    const objectFontSize = $('#object-font-size');
+    const toggleBold = $('#toggle-bold');
+    const toggleItalic = $('#toggle-italic');
+    const toggleUnderline = $('#toggle-underline');
+    const toggleStrike = $('#toggle-strike');
+    const alignLeft = $('#align-left');
+    const alignCenter = $('#align-center');
+    const alignRight = $('#align-right');
 
     const chatMessagesEl = $('#chat-messages');
     const sessionFileChip = $('#session-file-chip');
@@ -967,6 +1220,7 @@
     const bboxCountEl = $('#bbox-count');
     const btnSend = $('#btn-send');
     const btnToggleLogs = $('#btn-toggle-logs');
+    const editorHint = $('#editor-hint');
 
     const runsSection = $('#runs-section');
     const runsListEl = $('#runs-list');
@@ -988,6 +1242,18 @@
 
     function clamp(v, min, max) {
       return Math.max(min, Math.min(max, v));
+    }
+
+    function getDirectSaveState(slide) {
+      if (!directSaveStateBySlide.has(slide)) {
+        directSaveStateBySlide.set(slide, {
+          timer: null,
+          pendingHtml: '',
+          pendingMessage: '',
+          chain: Promise.resolve(),
+        });
+      }
+      return directSaveStateBySlide.get(slide);
     }
 
     function escapeHtml(str) {
@@ -1012,6 +1278,31 @@
 
     function normalizeModelName(value) {
       return typeof value === 'string' ? value.trim() : '';
+    }
+
+    function normalizeHexColor(value, fallback = '#111111') {
+      if (typeof value !== 'string') return fallback;
+      const hexMatch = value.trim().match(/^#([0-9a-f]{6})$/i);
+      if (hexMatch) {
+        return `#${hexMatch[1].toLowerCase()}`;
+      }
+
+      const rgbMatch = value.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+      if (!rgbMatch) return fallback;
+      const toHex = (part) => Number(part).toString(16).padStart(2, '0');
+      return `#${toHex(rgbMatch[1])}${toHex(rgbMatch[2])}${toHex(rgbMatch[3])}`;
+    }
+
+    function parsePixelValue(value, fallback = 24) {
+      const parsed = Number.parseFloat(String(value || '').replace('px', ''));
+      if (!Number.isFinite(parsed)) return fallback;
+      return Math.round(parsed);
+    }
+
+    function isBoldFontWeight(value) {
+      const numeric = Number.parseInt(value, 10);
+      if (Number.isFinite(numeric)) return numeric >= 600;
+      return /bold/i.test(String(value || ''));
     }
 
     function loadSavedModel() {
@@ -1091,6 +1382,7 @@
           messages: [],
           boxes: [],
           selectedBoxId: null,
+          selectedObjectXPath: '',
         });
       }
       return slideStates.get(slide);
@@ -1237,8 +1529,9 @@
     function scaleSlide() {
       const padX = 48;
       const padY = 48;
+      const toolboxHeight = slideToolbox?.offsetHeight || 0;
       const availW = slidePanel.clientWidth - padX;
-      const availH = slidePanel.clientHeight - padY;
+      const availH = slidePanel.clientHeight - padY - toolboxHeight;
       if (availW <= 0 || availH <= 0) return;
 
       const scale = Math.min(availW / SLIDE_W, availH / SLIDE_H) * 0.95;
@@ -1271,6 +1564,7 @@
           ].join('');
         })
         .join('');
+      bboxLayer.classList.toggle('inert', toolMode !== TOOL_MODE_DRAW);
 
       const pendingCount = state.boxes.filter((box) => normalizeBoxStatus(box.status) === 'pending').length;
       const reviewCount = state.boxes.length - pendingCount;
@@ -1319,6 +1613,7 @@
     }
 
     function startDrawing(event) {
+      if (toolMode !== TOOL_MODE_DRAW) return;
       if (event.button !== 0) return;
       event.preventDefault();
 
@@ -1332,6 +1627,7 @@
     }
 
     function moveDrawing(event) {
+      if (toolMode !== TOOL_MODE_DRAW) return;
       if (!drawing || !drawStart) return;
       const current = clientToSlidePoint(event.clientX, event.clientY);
 
@@ -1347,6 +1643,7 @@
     }
 
     function endDrawing(event) {
+      if (toolMode !== TOOL_MODE_DRAW) return;
       if (!drawing || !drawStart) return;
 
       const slide = currentSlideFile();
@@ -1393,6 +1690,7 @@
     }
 
     bboxLayer.addEventListener('click', (event) => {
+      if (toolMode !== TOOL_MODE_DRAW) return;
       const slide = currentSlideFile();
       if (!slide) return;
 
@@ -1543,6 +1841,338 @@
     }
 
     // -------------------------------------------------------------------------
+    // Direct object edit
+    // -------------------------------------------------------------------------
+    function resolveXPath(doc, xpath) {
+      if (!doc || typeof xpath !== 'string' || xpath.trim() === '') return null;
+      try {
+        return doc.evaluate(xpath, doc, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      } catch {
+        return null;
+      }
+    }
+
+    function isElementNode(node) {
+      return Boolean(node) && node.nodeType === Node.ELEMENT_NODE;
+    }
+
+    function getSelectedObjectElement(slide = currentSlideFile()) {
+      if (!slide) return null;
+      const state = getSlideState(slide);
+      const xpath = state.selectedObjectXPath;
+      if (!xpath) return null;
+
+      const doc = slideIframe.contentDocument;
+      const el = resolveXPath(doc, xpath);
+      return isElementNode(el) ? el : null;
+    }
+
+    function isSelectableElement(el) {
+      if (!isElementNode(el)) return false;
+      const tag = el.tagName.toLowerCase();
+      if (NON_SELECTABLE_TAGS.has(tag)) return false;
+      const rect = el.getBoundingClientRect();
+      return rect.width > 1 && rect.height > 1;
+    }
+
+    function isTextEditableElement(el) {
+      if (!isElementNode(el)) return false;
+      const tag = el.tagName.toLowerCase();
+      if (!DIRECT_TEXT_TAGS.has(tag)) return false;
+      return el.children.length === 0;
+    }
+
+    function getSelectableTargetAt(clientX, clientY) {
+      const doc = slideIframe.contentDocument;
+      if (!doc) return null;
+
+      const point = clientToSlidePoint(clientX, clientY);
+      let node = doc.elementFromPoint(point.x, point.y);
+      while (node && !isSelectableElement(node)) {
+        node = node.parentElement;
+      }
+      return isElementNode(node) ? node : null;
+    }
+
+    function elementToSlideRect(el) {
+      if (!isElementNode(el)) return null;
+      const rect = el.getBoundingClientRect();
+      if (!rect.width || !rect.height) return null;
+      return {
+        x: clamp(Math.round(rect.left), 0, SLIDE_W),
+        y: clamp(Math.round(rect.top), 0, SLIDE_H),
+        width: Math.max(1, Math.round(rect.width)),
+        height: Math.max(1, Math.round(rect.height)),
+      };
+    }
+
+    function applyOverlayRect(node, rect) {
+      if (!node || !rect) {
+        if (node) node.style.display = 'none';
+        return;
+      }
+
+      node.style.display = 'block';
+      node.style.left = `${rect.x}px`;
+      node.style.top = `${rect.y}px`;
+      node.style.width = `${rect.width}px`;
+      node.style.height = `${rect.height}px`;
+    }
+
+    function getSelectedObjectSummary(el) {
+      if (!isElementNode(el)) return 'No object selected';
+      const tag = el.tagName.toLowerCase();
+      const text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+      return `${tag} · ${text || '(no text)'}`.slice(0, 72);
+    }
+
+    function readSelectedObjectStyleState(el) {
+      const frameWindow = slideIframe.contentWindow;
+      const styles = frameWindow?.getComputedStyle ? frameWindow.getComputedStyle(el) : null;
+      const textDecorationLine = styles?.textDecorationLine || '';
+      return {
+        textEditable: isTextEditableElement(el),
+        textValue: (el.textContent || '').trim(),
+        textColor: normalizeHexColor(styles?.color, '#111111'),
+        backgroundColor: normalizeHexColor(styles?.backgroundColor, '#ffffff'),
+        fontSize: parsePixelValue(styles?.fontSize, 24),
+        bold: isBoldFontWeight(styles?.fontWeight),
+        italic: styles?.fontStyle === 'italic',
+        underline: /\bunderline\b/.test(textDecorationLine),
+        strike: /\bline-through\b/.test(textDecorationLine),
+        textAlign: styles?.textAlign || 'left',
+      };
+    }
+
+    function setToggleActive(button, active) {
+      button.classList.toggle('active', Boolean(active));
+      button.setAttribute('aria-pressed', active ? 'true' : 'false');
+    }
+
+    function updateSelectedObjectChip(text, empty = false) {
+      selectedObjectChip.textContent = text;
+      selectedObjectChip.classList.toggle('empty', empty);
+    }
+
+    function updateObjectEditorControls({ preserveTextInput = false } = {}) {
+      const wasHidden = directEditControls.hidden;
+      const selected = toolMode === TOOL_MODE_SELECT ? getSelectedObjectElement() : null;
+      directEditControls.hidden = !selected;
+
+      if (!selected) {
+        updateSelectedObjectChip('No object selected', true);
+        objectTextInput.value = '';
+        objectTextInput.disabled = true;
+        objectFontSize.value = '24';
+        objectTextColor.value = '#111111';
+        objectBgColor.value = '#ffffff';
+        setToggleActive(toggleBold, false);
+        setToggleActive(toggleItalic, false);
+        setToggleActive(toggleUnderline, false);
+        setToggleActive(toggleStrike, false);
+        setToggleActive(alignLeft, false);
+        setToggleActive(alignCenter, false);
+        setToggleActive(alignRight, false);
+        return;
+      }
+
+      const snapshot = readSelectedObjectStyleState(selected);
+      syncingDirectControls = true;
+      try {
+        updateSelectedObjectChip(getSelectedObjectSummary(selected), false);
+        objectTextInput.disabled = !snapshot.textEditable;
+        if (!preserveTextInput || document.activeElement !== objectTextInput) {
+          objectTextInput.value = snapshot.textEditable ? snapshot.textValue : '';
+        }
+        objectTextColor.value = snapshot.textColor;
+        objectBgColor.value = snapshot.backgroundColor;
+        objectFontSize.value = String(snapshot.fontSize);
+        setToggleActive(toggleBold, snapshot.bold);
+        setToggleActive(toggleItalic, snapshot.italic);
+        setToggleActive(toggleUnderline, snapshot.underline);
+        setToggleActive(toggleStrike, snapshot.strike);
+        setToggleActive(alignLeft, snapshot.textAlign === 'left' || snapshot.textAlign === 'start');
+        setToggleActive(alignCenter, snapshot.textAlign === 'center');
+        setToggleActive(alignRight, snapshot.textAlign === 'right' || snapshot.textAlign === 'end');
+      } finally {
+        syncingDirectControls = false;
+      }
+
+      if (wasHidden !== directEditControls.hidden) {
+        scaleSlide();
+      }
+    }
+
+    function renderObjectSelection() {
+      const selectedEl = toolMode === TOOL_MODE_SELECT ? getSelectedObjectElement() : null;
+      const hoveredEl = toolMode === TOOL_MODE_SELECT
+        ? resolveXPath(slideIframe.contentDocument, hoveredObjectXPath)
+        : null;
+
+      const selectedRect = selectedEl ? elementToSlideRect(selectedEl) : null;
+      const hoveredRect = hoveredEl && hoveredEl !== selectedEl ? elementToSlideRect(hoveredEl) : null;
+      applyOverlayRect(objectSelectedBox, selectedRect);
+      applyOverlayRect(objectHoverBox, hoveredRect);
+    }
+
+    function updateToolModeUI() {
+      const isDraw = toolMode === TOOL_MODE_DRAW;
+      slidePanel.classList.toggle('mode-draw', isDraw);
+      slidePanel.classList.toggle('mode-select', !isDraw);
+      toolModeDrawBtn.classList.toggle('active', isDraw);
+      toolModeSelectBtn.classList.toggle('active', !isDraw);
+      toolModeDrawBtn.setAttribute('aria-pressed', isDraw ? 'true' : 'false');
+      toolModeSelectBtn.setAttribute('aria-pressed', !isDraw ? 'true' : 'false');
+      editorHint.textContent = isDraw
+        ? 'Drag on the slide to add red pending bboxes. Cmd/Ctrl+Enter to run.'
+        : 'Click a slide object to edit its text and styles immediately.';
+      renderBboxes();
+      renderObjectSelection();
+      updateObjectEditorControls();
+      scaleSlide();
+    }
+
+    function setToolMode(mode) {
+      toolMode = mode === TOOL_MODE_SELECT ? TOOL_MODE_SELECT : TOOL_MODE_DRAW;
+      drawing = false;
+      drawStart = null;
+      drawBox.style.display = 'none';
+      if (toolMode !== TOOL_MODE_SELECT) {
+        hoveredObjectXPath = '';
+      }
+      updateToolModeUI();
+      setStatus(toolMode === TOOL_MODE_SELECT ? 'Select mode enabled.' : 'BBox draw mode enabled.');
+    }
+
+    function setSelectedObjectXPath(xpath, statusMessage = 'Object selected.') {
+      const slide = currentSlideFile();
+      if (!slide) return;
+      const state = getSlideState(slide);
+      state.selectedObjectXPath = xpath || '';
+      hoveredObjectXPath = xpath || '';
+      renderObjectSelection();
+      updateObjectEditorControls();
+      if (statusMessage) {
+        setStatus(statusMessage);
+      }
+    }
+
+    function updateHoveredObjectFromPointer(clientX, clientY) {
+      if (toolMode !== TOOL_MODE_SELECT) return;
+      const target = getSelectableTargetAt(clientX, clientY);
+      hoveredObjectXPath = target ? getXPath(target) : '';
+      renderObjectSelection();
+    }
+
+    function clearHoveredObject() {
+      hoveredObjectXPath = '';
+      renderObjectSelection();
+    }
+
+    function serializeSlideDocument(doc) {
+      if (!doc?.documentElement) return '';
+      const doctype = doc.doctype ? `<!DOCTYPE ${doc.doctype.name}>` : '<!DOCTYPE html>';
+      return `${doctype}\n${doc.documentElement.outerHTML}`;
+    }
+
+    async function persistDirectSlideHtml(slide, html, message) {
+      if (!slide || !html) return;
+
+      try {
+        const res = await fetch(`/api/slides/${encodeURIComponent(slide)}/save`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ slide, html }),
+        });
+        const data = await res.json().catch(() => ({}));
+
+        if (!res.ok) {
+          throw new Error(data.error || `Save failed with HTTP ${res.status}`);
+        }
+
+        localFileUpdateBySlide.set(slide, Date.now());
+        if (slide === currentSlideFile()) {
+          setStatus(message || `${slide} saved.`);
+        }
+      } catch (error) {
+        addChatMessage('error', `[${slide}] Direct edit save failed: ${error.message}`, slide);
+        setStatus(`Error: ${error.message}`);
+      }
+    }
+
+    function queueDirectSave(slide, html, message) {
+      const saveState = getDirectSaveState(slide);
+      if (!html) return saveState.chain;
+      saveState.chain = saveState.chain
+        .catch(() => {})
+        .then(() => persistDirectSlideHtml(slide, html, message));
+      return saveState.chain;
+    }
+
+    function scheduleDirectSave(delay = 0, message = 'Object updated and saved.') {
+      const slide = currentSlideFile();
+      const html = serializeSlideDocument(slideIframe.contentDocument);
+      if (!slide || !html) return;
+
+      const saveState = getDirectSaveState(slide);
+      saveState.pendingHtml = html;
+      saveState.pendingMessage = message;
+      if (saveState.timer) {
+        window.clearTimeout(saveState.timer);
+      }
+      saveState.timer = window.setTimeout(() => {
+        saveState.timer = null;
+        const nextHtml = saveState.pendingHtml;
+        const nextMessage = saveState.pendingMessage;
+        saveState.pendingHtml = '';
+        queueDirectSave(slide, nextHtml, nextMessage);
+      }, Math.max(0, delay));
+    }
+
+    async function flushDirectSaveForSlide(slide) {
+      if (!slide) return;
+
+      const saveState = getDirectSaveState(slide);
+      if (saveState.timer) {
+        window.clearTimeout(saveState.timer);
+        saveState.timer = null;
+        const html = saveState.pendingHtml;
+        const message = saveState.pendingMessage;
+        saveState.pendingHtml = '';
+        await queueDirectSave(slide, html, message);
+        return;
+      }
+
+      await saveState.chain.catch(() => {});
+    }
+
+    function applyTextDecorationToken(el, token, shouldEnable) {
+      const frameWindow = slideIframe.contentWindow;
+      const styles = frameWindow?.getComputedStyle ? frameWindow.getComputedStyle(el) : null;
+      const parts = new Set(
+        String(styles?.textDecorationLine || '')
+          .split(/\s+/)
+          .filter((part) => part === 'underline' || part === 'line-through'),
+      );
+      if (shouldEnable) {
+        parts.add(token);
+      } else {
+        parts.delete(token);
+      }
+      el.style.textDecorationLine = parts.size > 0 ? Array.from(parts).join(' ') : 'none';
+    }
+
+    function mutateSelectedObject(mutator, message, { delay = 0, preserveTextInput = false } = {}) {
+      const selected = getSelectedObjectElement();
+      if (!selected) return;
+      mutator(selected);
+      renderObjectSelection();
+      updateObjectEditorControls({ preserveTextInput });
+      scheduleDirectSave(delay, message);
+      setStatus('Saving direct edit...');
+    }
+
+    // -------------------------------------------------------------------------
     // Send
     // -------------------------------------------------------------------------
     function updateSlideStatusChip() {
@@ -1590,6 +2220,8 @@
     async function applyChanges() {
       const slide = currentSlideFile();
       if (!slide) return;
+
+      await flushDirectSaveForSlide(slide);
 
       const state = getSlideState(slide);
       const prompt = (promptInput.value || '').trim();
@@ -1702,10 +2334,14 @@
       state.model = normalizeModelName(modelSelect.value) || state.model || defaultModel;
     }
 
-    function goToSlide(index) {
+    async function goToSlide(index) {
       if (index < 0 || index >= slides.length) return;
 
+      const previousSlide = currentSlideFile();
       persistCurrentSlideDraft();
+      if (previousSlide) {
+        await flushDirectSaveForSlide(previousSlide);
+      }
 
       currentIndex = index;
       const slide = currentSlideFile();
@@ -1722,8 +2358,11 @@
       selectedModel = state.model;
       modelSelect.value = selectedModel;
       promptInput.value = state.prompt || '';
+      hoveredObjectXPath = '';
       renderChatMessages();
       renderBboxes();
+      renderObjectSelection();
+      updateObjectEditorControls();
       updateSendState();
       setStatus(`Loaded ${slide}`);
     }
@@ -1852,6 +2491,11 @@
         try {
           const { file } = JSON.parse(event.data);
           if (file === currentSlideFile()) {
+            const updatedAt = localFileUpdateBySlide.get(file);
+            if (updatedAt && Date.now() - updatedAt < 2000) {
+              localFileUpdateBySlide.delete(file);
+              return;
+            }
             slideIframe.src = slideIframe.src;
           }
         } catch (error) {
@@ -1895,12 +2539,32 @@
     // -------------------------------------------------------------------------
     // Event wiring
     // -------------------------------------------------------------------------
-    btnPrev.addEventListener('click', () => goToSlide(currentIndex - 1));
-    btnNext.addEventListener('click', () => goToSlide(currentIndex + 1));
+    btnPrev.addEventListener('click', () => { void goToSlide(currentIndex - 1); });
+    btnNext.addEventListener('click', () => { void goToSlide(currentIndex + 1); });
+
+    toolModeDrawBtn.addEventListener('click', () => setToolMode(TOOL_MODE_DRAW));
+    toolModeSelectBtn.addEventListener('click', () => setToolMode(TOOL_MODE_SELECT));
 
     btnClearBboxes.addEventListener('click', clearBboxesForCurrentSlide);
 
     drawLayer.addEventListener('mousedown', startDrawing);
+    drawLayer.addEventListener('mousemove', (event) => {
+      if (toolMode !== TOOL_MODE_SELECT) return;
+      updateHoveredObjectFromPointer(event.clientX, event.clientY);
+    });
+    drawLayer.addEventListener('mouseleave', clearHoveredObject);
+    drawLayer.addEventListener('click', (event) => {
+      if (toolMode !== TOOL_MODE_SELECT) return;
+      const target = getSelectableTargetAt(event.clientX, event.clientY);
+      if (!target) {
+        setSelectedObjectXPath('', 'No selectable object at this point.');
+        return;
+      }
+
+      const xpath = getXPath(target);
+      const tag = target.tagName.toLowerCase();
+      setSelectedObjectXPath(xpath, `Selected ${tag} on ${currentSlideFile()}.`);
+    });
     window.addEventListener('mousemove', moveDrawing);
     window.addEventListener('mouseup', endDrawing);
 
@@ -1938,6 +2602,81 @@
       updateSendState();
     });
 
+    objectTextInput.addEventListener('input', () => {
+      if (syncingDirectControls || objectTextInput.disabled) return;
+      mutateSelectedObject((el) => {
+        el.textContent = objectTextInput.value;
+      }, 'Object text updated and saved.', { delay: 180, preserveTextInput: true });
+    });
+
+    objectFontSize.addEventListener('input', () => {
+      if (syncingDirectControls) return;
+      const size = clamp(Number.parseInt(objectFontSize.value || '24', 10) || 24, 8, 180);
+      mutateSelectedObject((el) => {
+        el.style.fontSize = `${size}px`;
+      }, 'Object font size updated and saved.');
+    });
+
+    objectTextColor.addEventListener('input', () => {
+      if (syncingDirectControls) return;
+      mutateSelectedObject((el) => {
+        el.style.color = objectTextColor.value;
+      }, 'Object text color updated and saved.');
+    });
+
+    objectBgColor.addEventListener('input', () => {
+      if (syncingDirectControls) return;
+      mutateSelectedObject((el) => {
+        el.style.backgroundColor = objectBgColor.value;
+      }, 'Object background color updated and saved.');
+    });
+
+    toggleBold.addEventListener('click', () => {
+      mutateSelectedObject((el) => {
+        const nextBold = !readSelectedObjectStyleState(el).bold;
+        el.style.fontWeight = nextBold ? '700' : '400';
+      }, 'Object font weight updated and saved.');
+    });
+
+    toggleItalic.addEventListener('click', () => {
+      mutateSelectedObject((el) => {
+        const nextItalic = !readSelectedObjectStyleState(el).italic;
+        el.style.fontStyle = nextItalic ? 'italic' : 'normal';
+      }, 'Object font style updated and saved.');
+    });
+
+    toggleUnderline.addEventListener('click', () => {
+      mutateSelectedObject((el) => {
+        const nextUnderline = !readSelectedObjectStyleState(el).underline;
+        applyTextDecorationToken(el, 'underline', nextUnderline);
+      }, 'Object underline updated and saved.');
+    });
+
+    toggleStrike.addEventListener('click', () => {
+      mutateSelectedObject((el) => {
+        const nextStrike = !readSelectedObjectStyleState(el).strike;
+        applyTextDecorationToken(el, 'line-through', nextStrike);
+      }, 'Object strikethrough updated and saved.');
+    });
+
+    alignLeft.addEventListener('click', () => {
+      mutateSelectedObject((el) => {
+        el.style.textAlign = 'left';
+      }, 'Object alignment updated and saved.');
+    });
+
+    alignCenter.addEventListener('click', () => {
+      mutateSelectedObject((el) => {
+        el.style.textAlign = 'center';
+      }, 'Object alignment updated and saved.');
+    });
+
+    alignRight.addEventListener('click', () => {
+      mutateSelectedObject((el) => {
+        el.style.textAlign = 'right';
+      }, 'Object alignment updated and saved.');
+    });
+
     document.addEventListener('keydown', (event) => {
       const inTextarea = document.activeElement === promptInput;
 
@@ -1955,16 +2694,26 @@
 
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
-        goToSlide(currentIndex - 1);
+        void goToSlide(currentIndex - 1);
       } else if (event.key === 'ArrowRight') {
         event.preventDefault();
-        goToSlide(currentIndex + 1);
+        void goToSlide(currentIndex + 1);
       }
     });
 
     window.addEventListener('resize', scaleSlide);
     slideIframe.addEventListener('load', () => {
+      const slide = currentSlideFile();
+      if (slide) {
+        const state = getSlideState(slide);
+        if (state.selectedObjectXPath && !getSelectedObjectElement(slide)) {
+          state.selectedObjectXPath = '';
+        }
+      }
+      hoveredObjectXPath = '';
       renderBboxes();
+      renderObjectSelection();
+      updateObjectEditorControls();
       updateSendState();
     });
 
@@ -1990,7 +2739,8 @@
         }
 
         await loadModelOptions();
-        goToSlide(0);
+        updateToolModeUI();
+        await goToSlide(0);
         scaleSlide();
         await loadRunsInitial();
         connectSSE();

--- a/src/editor/editor.html
+++ b/src/editor/editor.html
@@ -153,20 +153,20 @@
     }
 
     .slide-toolbox {
-      width: min(100%, 996px);
+      width: min(100%, 1180px);
       display: flex;
-      align-items: center;
+      flex-direction: column;
       gap: 10px;
-      flex-wrap: wrap;
-      padding: 10px 12px;
+      padding: 14px 16px 12px;
       border: 1px solid #293444;
-      border-radius: 12px;
-      background: rgba(15, 21, 29, 0.92);
+      border-radius: 20px;
+      background: rgba(15, 21, 29, 0.94);
       box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
       position: relative;
       z-index: 20;
       align-self: center;
       flex: 0 0 auto;
+      overflow: visible;
     }
 
     .slide-stage {
@@ -188,17 +188,83 @@
       gap: 6px;
     }
 
+    .tool-separator {
+      width: 1px;
+      height: 34px;
+      flex: 0 0 auto;
+      background: linear-gradient(180deg, rgba(58, 72, 90, 0.1) 0%, rgba(58, 72, 90, 0.8) 48%, rgba(58, 72, 90, 0.1) 100%);
+    }
+
+    .toolbar-section {
+      min-width: 0;
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .toolbar-section[hidden] {
+      display: none !important;
+    }
+
+    .tool-strip {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
+      min-height: 46px;
+    }
+
+    .bbox-toolbar,
+    .select-toolbar {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+      flex: 1;
+    }
+
+    .bbox-toolbar {
+      justify-content: flex-start;
+    }
+
+    .bbox-toolbar[hidden],
+    .select-toolbar[hidden] {
+      display: none !important;
+    }
+
+    .select-toolbar {
+      justify-content: flex-start;
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      padding-bottom: 2px;
+    }
+
+    .toolbar-divider {
+      width: 1px;
+      height: 34px;
+      flex: 0 0 auto;
+      background: linear-gradient(180deg, rgba(58, 72, 90, 0.1) 0%, rgba(58, 72, 90, 0.8) 48%, rgba(58, 72, 90, 0.1) 100%);
+    }
+
     .tool-mode-btn {
       border: 1px solid #2c3847;
       background: #18212c;
       color: #d6e1ec;
-      border-radius: 8px;
-      height: 32px;
-      padding: 0 10px;
+      border-radius: 12px;
+      height: 46px;
+      padding: 0 16px;
       font-size: 12px;
       font-family: var(--mono);
+      font-weight: 700;
       cursor: pointer;
       transition: background 0.15s, border-color 0.15s;
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      white-space: nowrap;
     }
 
     .tool-mode-btn:hover {
@@ -209,6 +275,66 @@
       border-color: #3963a4;
       background: #1d3355;
       color: #e8f0fb;
+    }
+
+    .tool-icon-btn {
+      border: 1px solid #2c3847;
+      background: #141c26;
+      color: #d9e5f3;
+      border-radius: 12px;
+      min-width: 46px;
+      height: 46px;
+      padding: 0 12px;
+      font-size: 14px;
+      font-family: var(--mono);
+      font-weight: 700;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s, opacity 0.15s;
+      flex: 0 0 auto;
+    }
+
+    .tool-icon-btn:hover {
+      background: #1b2430;
+    }
+
+    .tool-icon-btn.active {
+      border-color: #3b82f6;
+      background: #18365d;
+      color: #eff6ff;
+    }
+
+    .tool-icon-btn:disabled {
+      opacity: 0.42;
+      cursor: default;
+      color: #8392a5;
+      background: #121922;
+    }
+
+    .tool-icon-btn:disabled:hover {
+      background: #121922;
+    }
+
+    .tool-icon-btn.tight {
+      min-width: 42px;
+      width: 42px;
+      padding: 0;
+    }
+
+    .tool-icon {
+      width: 16px;
+      height: 16px;
+      display: block;
+      stroke: currentColor;
+      stroke-width: 1.8;
+      fill: none;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      flex: 0 0 auto;
+    }
+
+    .tool-mode-btn .tool-icon {
+      width: 15px;
+      height: 15px;
     }
 
     .selected-object-chip {
@@ -719,8 +845,14 @@
       color: var(--text-2);
       font-size: 11px;
       font-weight: 700;
-      margin-left: auto;
       font-family: var(--mono);
+      flex: 0 0 auto;
+      min-width: 128px;
+    }
+
+    .prompt-shell {
+      flex: 1;
+      min-width: 220px;
     }
 
     .context-chips {
@@ -784,19 +916,17 @@
     }
 
     .prompt-input {
-      width: 100%;
-      min-height: 84px;
-      max-height: 200px;
-      resize: vertical;
-      border-radius: 8px;
+      flex: 1;
+      min-width: 220px;
+      height: 46px;
+      border-radius: 12px;
       border: 1px solid #2e3948;
       background: #0f141a;
       color: #e6edf3;
       font-size: 13px;
       font-family: var(--sans);
-      line-height: 1.45;
-      padding: 10px;
-      padding-bottom: 50px;
+      line-height: 1;
+      padding: 0 14px;
       outline: none;
     }
 
@@ -814,25 +944,11 @@
       font-family: var(--mono);
     }
 
-    .prompt-shell {
-      position: relative;
-      width: 100%;
-    }
-
-    .prompt-toolbar {
-      position: absolute;
-      right: 10px;
-      bottom: 10px;
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-    }
-
     .model-select {
       min-width: 176px;
       width: 176px;
-      height: 32px;
-      border-radius: 8px;
+      height: 46px;
+      border-radius: 12px;
       border: 1px solid #2f3b4a;
       background: #111722;
       color: #e6edf3;
@@ -849,12 +965,12 @@
     .btn-send {
       background: linear-gradient(180deg, #2754a7 0%, #1d3f84 100%);
       color: #dce7f6;
-      min-width: 32px;
-      width: 32px;
-      height: 32px;
+      min-width: 46px;
+      width: 46px;
+      height: 46px;
       padding: 0;
       border: 1px solid #304f85;
-      border-radius: 9px;
+      border-radius: 12px;
     }
 
     .btn-send:hover { background: linear-gradient(180deg, #2d63c8 0%, #224a99 100%); }
@@ -865,6 +981,106 @@
       display: block;
       fill: currentColor;
       transform: translateX(0.5px);
+    }
+
+    .tool-popovers {
+      position: absolute;
+      inset: calc(100% + 10px) 0 auto 0;
+      z-index: 30;
+      pointer-events: none;
+      min-height: 0;
+    }
+
+    .editor-popover {
+      position: absolute;
+      top: 0;
+      width: 248px;
+      padding: 12px;
+      border-radius: 14px;
+      border: 1px solid #2f3b4a;
+      background: rgba(15, 21, 29, 0.98);
+      box-shadow: 0 18px 34px rgba(0, 0, 0, 0.34);
+      display: flex;
+      align-items: flex-end;
+      gap: 10px;
+      pointer-events: auto;
+    }
+
+    .editor-popover[hidden] {
+      display: none !important;
+    }
+
+    .popover-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .popover-label {
+      color: #dbe6f3;
+      font-size: 11px;
+      font-weight: 700;
+      font-family: var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .popover-input,
+    .popover-number,
+    .popover-color {
+      width: 100%;
+      border-radius: 10px;
+      border: 1px solid #2f3b4a;
+      background: #111722;
+      color: #e6edf3;
+      font-size: 13px;
+      font-family: var(--sans);
+      outline: none;
+    }
+
+    .popover-input,
+    .popover-number {
+      height: 42px;
+      padding: 0 12px;
+    }
+
+    .popover-color {
+      height: 44px;
+      padding: 4px;
+      cursor: pointer;
+    }
+
+    .popover-input:focus,
+    .popover-number:focus {
+      border-color: #4f6d8f;
+    }
+
+    .popover-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+
+    .popover-apply-btn {
+      border: 1px solid #3b82f6;
+      background: #18365d;
+      color: #eff6ff;
+      border-radius: 10px;
+      height: 34px;
+      padding: 0 12px;
+      font-size: 12px;
+      font-family: var(--mono);
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .hint {
+      min-height: 14px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .runs-section {
@@ -1011,30 +1227,17 @@
     }
 
     @media (max-width: 1380px) {
-      .sidebar {
-        width: 390px;
-        min-width: 300px;
-      }
       .slide-toolbox {
-        justify-content: flex-start;
-      }
-      .selected-object-chip {
-        max-width: 100%;
-      }
-      .tool-row {
-        flex-wrap: wrap;
-      }
-      .prompt-toolbar {
-        position: static;
-        margin-top: 8px;
+        width: calc(100% - 8px);
+        padding: 12px;
+        gap: 10px;
       }
       .model-select {
         min-width: 138px;
         width: 138px;
       }
       .prompt-input {
-        min-height: 78px;
-        padding-bottom: 10px;
+        min-width: 160px;
       }
     }
   </style>
@@ -1055,40 +1258,102 @@
     <div class="main-content">
       <div class="slide-panel" id="slide-panel">
         <div class="slide-toolbox" id="slide-toolbox">
-          <div class="tool-mode-group">
-            <button type="button" class="tool-mode-btn active" id="tool-mode-draw" aria-pressed="true">Draw Boxes</button>
-            <button type="button" class="tool-mode-btn" id="tool-mode-select" aria-pressed="false">Select Object</button>
-          </div>
-          <div class="selected-object-chip empty" id="selected-object-chip">No object selected</div>
-          <div class="direct-edit-controls" id="direct-edit-controls" hidden>
-            <label class="direct-edit-group" for="object-text-input">
-              <span class="direct-edit-label">Text</span>
-              <input id="object-text-input" class="direct-input direct-text-input" type="text" placeholder="Selected text">
-            </label>
-            <label class="direct-edit-group" for="object-text-color">
-              <span class="direct-edit-label">Text</span>
-              <input id="object-text-color" class="direct-color" type="color" value="#111111" title="Text color">
-            </label>
-            <label class="direct-edit-group" for="object-bg-color">
-              <span class="direct-edit-label">Bg</span>
-              <input id="object-bg-color" class="direct-color" type="color" value="#ffffff" title="Background color">
-            </label>
-            <label class="direct-edit-group" for="object-font-size">
-              <span class="direct-edit-label">Size</span>
-              <input id="object-font-size" class="direct-number" type="number" min="8" max="180" step="1" value="24">
-            </label>
-            <div class="direct-toggle-group">
-              <button type="button" class="tool-mode-btn style-toggle" id="toggle-bold" title="Bold">B</button>
-              <button type="button" class="tool-mode-btn style-toggle" id="toggle-italic" title="Italic">I</button>
-              <button type="button" class="tool-mode-btn style-toggle" id="toggle-underline" title="Underline">U</button>
-              <button type="button" class="tool-mode-btn style-toggle" id="toggle-strike" title="Strikethrough">S</button>
+          <div class="tool-strip" id="tool-strip">
+            <div class="tool-mode-group">
+              <button type="button" class="tool-mode-btn active" id="tool-mode-draw" aria-pressed="true" title="BBox mode">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M5 5h14v14H5zM9 5v14M15 5v14M5 9h14M5 15h14"/>
+                </svg>
+                <span>BBox</span>
+              </button>
+              <button type="button" class="tool-mode-btn" id="tool-mode-select" aria-pressed="false" title="Select object mode">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="m6 4 11 8-5 1.2L14.6 20l-2.5 1-2.6-6.8L6 15z"/>
+                </svg>
+                <span>Select</span>
+              </button>
             </div>
-            <div class="direct-align-group">
-              <button type="button" class="tool-mode-btn align-btn" id="align-left" title="Align left">L</button>
-              <button type="button" class="tool-mode-btn align-btn" id="align-center" title="Align center">C</button>
-              <button type="button" class="tool-mode-btn align-btn" id="align-right" title="Align right">R</button>
+            <div class="toolbar-divider" aria-hidden="true"></div>
+            <div class="bbox-toolbar" id="bbox-toolbar">
+              <span class="bbox-count" id="bbox-count">0 pending · 0 review</span>
+              <div class="prompt-shell">
+                <input id="prompt-input" class="prompt-input" type="text" placeholder="Describe the edit for the selected red bbox">
+              </div>
+              <select id="model-select" class="model-select">
+                <option value="gpt-5.3-codex">gpt-5.3-codex</option>
+                <option value="gpt-5.3-codex-spark">gpt-5.3-codex-spark</option>
+              </select>
+              <button class="btn btn-send" id="btn-send" title="Run Codex" aria-label="Run Codex">
+                <svg class="btn-send-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M3.4 11.2 19.6 4.4c.8-.3 1.7.5 1.4 1.4l-6.8 16.2c-.3.8-1.4.9-1.9.1L9.2 16l-6.1-3.1c-.8-.5-.7-1.6.3-1.7Zm5.1 3.6 3.2 1.6 4.9-11.7-11.7 4.9 3.6 1.8 6.2-3.7c.4-.2.8.1.6.6l-6.8 6.5Z"/>
+                </svg>
+              </button>
+            </div>
+            <div class="select-toolbar" id="select-toolbar" hidden>
+              <button type="button" class="tool-icon-btn" id="select-action-text" title="Edit text">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M5 6h14M12 6v12M8 18h8"/>
+                </svg>
+              </button>
+              <button type="button" class="tool-icon-btn" id="select-action-text-color" title="Text color">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="m9 15 3-9 3 9M10.5 11h3"/>
+                  <path d="M6 19h12"/>
+                </svg>
+              </button>
+              <button type="button" class="tool-icon-btn" id="select-action-bg-color" title="Background color">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M5 7h14v10H5z"/>
+                  <path d="M7 17h10"/>
+                </svg>
+              </button>
+              <button type="button" class="tool-icon-btn" id="select-action-size" title="Font size">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M7 18 12 6l5 12M9.5 12h5"/>
+                </svg>
+              </button>
+              <div class="toolbar-divider" aria-hidden="true"></div>
+              <button type="button" class="tool-icon-btn style-toggle" id="toggle-bold" title="Bold">B</button>
+              <button type="button" class="tool-icon-btn style-toggle" id="toggle-italic" title="Italic">I</button>
+              <button type="button" class="tool-icon-btn style-toggle" id="toggle-underline" title="Underline">U</button>
+              <button type="button" class="tool-icon-btn style-toggle" id="toggle-strike" title="Strikethrough">S</button>
+              <div class="toolbar-divider" aria-hidden="true"></div>
+              <button type="button" class="tool-icon-btn align-btn" id="align-left" title="Align left">L</button>
+              <button type="button" class="tool-icon-btn align-btn" id="align-center" title="Align center">C</button>
+              <button type="button" class="tool-icon-btn align-btn" id="align-right" title="Align right">R</button>
             </div>
           </div>
+          <div class="tool-popover-layer" id="tool-popover-layer">
+            <section class="toolbar-popover" id="editor-popover-text" hidden>
+              <label class="popover-field" for="popover-text-input">
+                <span class="popover-label">Text</span>
+                <input id="popover-text-input" class="popover-input" type="text" placeholder="Edit selected text">
+              </label>
+              <button type="button" class="popover-apply-btn" id="popover-apply-text">Apply</button>
+            </section>
+            <section class="toolbar-popover" id="editor-popover-size" hidden>
+              <label class="popover-field" for="popover-size-input">
+                <span class="popover-label">Size</span>
+                <input id="popover-size-input" class="popover-input popover-number" type="number" min="8" max="180" step="1" value="24">
+              </label>
+              <button type="button" class="popover-apply-btn" id="popover-apply-size">Apply</button>
+            </section>
+            <section class="toolbar-popover" id="editor-popover-text-color" hidden>
+              <label class="popover-field" for="popover-text-color-input">
+                <span class="popover-label">Text color</span>
+                <input id="popover-text-color-input" class="popover-color" type="color" value="#111111">
+              </label>
+              <button type="button" class="popover-apply-btn" id="popover-apply-text-color">Apply</button>
+            </section>
+            <section class="toolbar-popover" id="editor-popover-bg-color" hidden>
+              <label class="popover-field" for="popover-bg-color-input">
+                <span class="popover-label">Background</span>
+                <input id="popover-bg-color-input" class="popover-color" type="color" value="#ffffff">
+              </label>
+              <button type="button" class="popover-apply-btn" id="popover-apply-bg-color">Apply</button>
+            </section>
+          </div>
+          <div class="hint" id="editor-hint">Drag on the slide to add red pending bboxes. Press Enter to run.</div>
         </div>
         <div class="slide-stage" id="slide-stage">
           <div class="slide-wrapper" id="slide-wrapper">
@@ -1105,48 +1370,6 @@
           </div>
         </div>
       </div>
-
-      <aside class="sidebar">
-        <section class="chat-section">
-          <div class="chat-header">
-            <div class="header-tabs">
-              <span class="header-tab active">CHAT</span>
-            </div>
-            <button class="btn-toggle-logs" id="btn-toggle-logs" title="Toggle execution records">LOGS</button>
-          </div>
-          <div class="session-strip">
-            <span class="session-file-chip" id="session-file-chip">--</span>
-          </div>
-          <div class="chat-messages" id="chat-messages"></div>
-
-          <div class="composer">
-            <div class="tool-row">
-              <div class="context-chips" id="context-chip-list"></div>
-              <span class="bbox-count" id="bbox-count">0 pending · 0 review</span>
-            </div>
-            <div class="hint" id="editor-hint">Drag on the slide to add red pending bboxes. Cmd/Ctrl+Enter to run.</div>
-            <div class="prompt-shell">
-              <textarea id="prompt-input" class="prompt-input" placeholder="Describe the edit for this slide..."></textarea>
-              <div class="prompt-toolbar">
-                <select id="model-select" class="model-select">
-                  <option value="gpt-5.3-codex">gpt-5.3-codex</option>
-                  <option value="gpt-5.3-codex-spark">gpt-5.3-codex-spark</option>
-                </select>
-                <button class="btn btn-send" id="btn-send" title="Run Codex" aria-label="Run Codex">
-                  <svg class="btn-send-icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M3.4 11.2 19.6 4.4c.8-.3 1.7.5 1.4 1.4l-6.8 16.2c-.3.8-1.4.9-1.9.1L9.2 16l-6.1-3.1c-.8-.5-.7-1.6.3-1.7Zm5.1 3.6 3.2 1.6 4.9-11.7-11.7 4.9 3.6 1.8 6.2-3.7c.4-.2.8.1.6.6l-6.8 6.5Z"/>
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section class="runs-section collapsed" id="runs-section">
-          <div class="section-label">Execution Records</div>
-          <div class="runs-list" id="runs-list"></div>
-        </section>
-      </aside>
     </div>
 
     <div class="status-bar">
@@ -1166,20 +1389,20 @@
     let currentIndex = 0;
     let drawStart = null;
     let drawing = false;
-    let logsVisible = false;
-
     const slideStates = new Map();
     const activeRunBySlide = new Map();
     const pendingRequestBySlide = new Set();
 
     const runsById = new Map();
-    const runLogsById = new Map();
-    let expandedRunId = null;
 
     const SLIDE_W = 960;
     const SLIDE_H = 540;
     const TOOL_MODE_DRAW = 'draw';
     const TOOL_MODE_SELECT = 'select';
+    const POPOVER_TEXT = 'text';
+    const POPOVER_TEXT_COLOR = 'text-color';
+    const POPOVER_BG_COLOR = 'bg-color';
+    const POPOVER_SIZE = 'size';
     const DEFAULT_MODELS = ['gpt-5.3-codex', 'gpt-5.3-codex-spark'];
     const DIRECT_TEXT_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
     const NON_SELECTABLE_TAGS = new Set(['html', 'head', 'body', 'script', 'style', 'link', 'meta', 'noscript']);
@@ -1187,8 +1410,8 @@
     let defaultModel = DEFAULT_MODELS[0];
     let selectedModel = defaultModel;
     let toolMode = TOOL_MODE_DRAW;
+    let openPopover = '';
     let hoveredObjectXPath = '';
-    let syncingDirectControls = false;
 
     const directSaveStateBySlide = new Map();
     const localFileUpdateBySlide = new Map();
@@ -1215,12 +1438,12 @@
     const drawBox = $('#draw-box');
     const toolModeDrawBtn = $('#tool-mode-draw');
     const toolModeSelectBtn = $('#tool-mode-select');
-    const selectedObjectChip = $('#selected-object-chip');
-    const directEditControls = $('#direct-edit-controls');
-    const objectTextInput = $('#object-text-input');
-    const objectTextColor = $('#object-text-color');
-    const objectBgColor = $('#object-bg-color');
-    const objectFontSize = $('#object-font-size');
+    const bboxToolbar = $('#bbox-toolbar');
+    const selectToolbar = $('#select-toolbar');
+    const selectActionText = $('#select-action-text');
+    const selectActionTextColor = $('#select-action-text-color');
+    const selectActionBgColor = $('#select-action-bg-color');
+    const selectActionSize = $('#select-action-size');
     const toggleBold = $('#toggle-bold');
     const toggleItalic = $('#toggle-italic');
     const toggleUnderline = $('#toggle-underline');
@@ -1228,6 +1451,19 @@
     const alignLeft = $('#align-left');
     const alignCenter = $('#align-center');
     const alignRight = $('#align-right');
+    const toolPopoverLayer = $('#tool-popover-layer');
+    const popoverText = $('#editor-popover-text');
+    const popoverTextInput = $('#popover-text-input');
+    const popoverApplyText = $('#popover-apply-text');
+    const popoverTextColor = $('#editor-popover-text-color');
+    const popoverTextColorInput = $('#popover-text-color-input');
+    const popoverApplyTextColor = $('#popover-apply-text-color');
+    const popoverBgColor = $('#editor-popover-bg-color');
+    const popoverBgColorInput = $('#popover-bg-color-input');
+    const popoverApplyBgColor = $('#popover-apply-bg-color');
+    const popoverSize = $('#editor-popover-size');
+    const popoverSizeInput = $('#popover-size-input');
+    const popoverApplySize = $('#popover-apply-size');
 
     const chatMessagesEl = $('#chat-messages');
     const sessionFileChip = $('#session-file-chip');
@@ -1237,11 +1473,7 @@
     const btnClearBboxes = $('#btn-clear-bboxes');
     const bboxCountEl = $('#bbox-count');
     const btnSend = $('#btn-send');
-    const btnToggleLogs = $('#btn-toggle-logs');
     const editorHint = $('#editor-hint');
-
-    const runsSection = $('#runs-section');
-    const runsListEl = $('#runs-list');
 
     const statusDot = $('#status-dot');
     const statusConn = $('#status-connection');
@@ -1437,6 +1669,7 @@
     }
 
     function renderChatMessages() {
+      if (!chatMessagesEl) return;
       const slide = currentSlideFile();
       if (!slide) {
         chatMessagesEl.innerHTML = '';
@@ -1465,81 +1698,7 @@
       chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
     }
 
-    function setLogsVisible(visible) {
-      logsVisible = Boolean(visible);
-      runsSection.classList.toggle('collapsed', !logsVisible);
-      btnToggleLogs.classList.toggle('active', logsVisible);
-      btnToggleLogs.textContent = logsVisible ? 'LOGS ON' : 'LOGS';
-    }
-
-    async function toggleRunLog(runId) {
-      if (expandedRunId === runId) {
-        expandedRunId = null;
-        renderRunsList();
-        return;
-      }
-
-      expandedRunId = runId;
-
-      if (!runLogsById.has(runId)) {
-        try {
-          const res = await fetch(`/api/runs/${encodeURIComponent(runId)}/log`);
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          const text = await res.text();
-          runLogsById.set(runId, text || '(empty log)');
-        } catch (error) {
-          runLogsById.set(runId, `Failed to load log: ${error.message}`);
-        }
-      }
-
-      renderRunsList();
-    }
-
-    function renderRunsList() {
-      const runs = Array.from(runsById.values())
-        .sort((a, b) => String(b.startedAt).localeCompare(String(a.startedAt)))
-        .slice(0, 60);
-
-      if (runs.length === 0) {
-        runsListEl.innerHTML = '<div class="run-meta">No runs yet.</div>';
-        return;
-      }
-
-      runsListEl.innerHTML = runs
-        .map((run) => {
-          const statusClass = run.status || 'idle';
-          const isExpanded = expandedRunId === run.runId;
-          const logText = isExpanded
-            ? escapeHtml(runLogsById.get(run.runId) || run.logPreview || '(no log)')
-            : '';
-
-          return [
-            `<div class="run-item">`,
-            `<div class="run-item-head">`,
-            `<span class="run-dot ${statusClass}"></span>`,
-            `<span class="run-slide">${escapeHtml(run.slide)}</span>`,
-            `</div>`,
-            `<div class="run-meta">${escapeHtml(run.status || 'idle')} | ${formatTime(run.startedAt)}</div>`,
-            `<div class="run-meta">model: ${escapeHtml(run.model || '-')}</div>`,
-            `<div class="run-meta">${escapeHtml(run.message || '')}</div>`,
-            `<div class="run-actions">`,
-            `<span class="run-meta">runId: ${escapeHtml(run.runId)}</span>`,
-            `<button class="btn btn-log" data-run-log-btn="${escapeHtml(run.runId)}">${isExpanded ? 'Hide Log' : 'View Log'}</button>`,
-            `</div>`,
-            isExpanded ? `<div class="run-log">${logText}</div>` : '',
-            `</div>`,
-          ].join('');
-        })
-        .join('');
-    }
-
-    runsListEl.addEventListener('click', async (event) => {
-      const button = event.target.closest('[data-run-log-btn]');
-      if (!button) return;
-      const runId = button.getAttribute('data-run-log-btn');
-      if (!runId) return;
-      await toggleRunLog(runId);
-    });
+    function renderRunsList() {}
 
     // -------------------------------------------------------------------------
     // Slide & bbox rendering
@@ -1591,14 +1750,15 @@
     }
 
     function renderContextChips() {
+      if (!contextChipList) return;
       const slide = currentSlideFile();
       if (!slide) {
         contextChipList.innerHTML = '';
-        sessionFileChip.textContent = '--';
+        if (sessionFileChip) sessionFileChip.textContent = '--';
         return;
       }
 
-      sessionFileChip.textContent = slide;
+      if (sessionFileChip) sessionFileChip.textContent = slide;
 
       const state = getSlideState(slide);
       if (!Array.isArray(state.boxes) || state.boxes.length === 0) {
@@ -1757,22 +1917,24 @@
       renderBboxes();
     });
 
-    contextChipList.addEventListener('click', (event) => {
-      const chip = event.target.closest('[data-chip-box-id]');
-      if (!chip) return;
+    if (contextChipList) {
+      contextChipList.addEventListener('click', (event) => {
+        const chip = event.target.closest('[data-chip-box-id]');
+        if (!chip) return;
 
-      const slide = currentSlideFile();
-      if (!slide) return;
+        const slide = currentSlideFile();
+        if (!slide) return;
 
-      const boxId = chip.getAttribute('data-chip-box-id');
-      const state = getSlideState(slide);
-      const boxExists = state.boxes.some((box) => box.id === boxId);
-      if (!boxExists) return;
+        const boxId = chip.getAttribute('data-chip-box-id');
+        const state = getSlideState(slide);
+        const boxExists = state.boxes.some((box) => box.id === boxId);
+        if (!boxExists) return;
 
-      state.selectedBoxId = boxId;
-      renderBboxes();
-      setStatus(`Selected ${slide} region.`);
-    });
+        state.selectedBoxId = boxId;
+        renderBboxes();
+        setStatus(`Selected ${slide} region.`);
+      });
+    }
 
     // -------------------------------------------------------------------------
     // XPath extraction
@@ -1936,13 +2098,6 @@
       node.style.height = `${rect.height}px`;
     }
 
-    function getSelectedObjectSummary(el) {
-      if (!isElementNode(el)) return 'No object selected';
-      const tag = el.tagName.toLowerCase();
-      const text = (el.textContent || '').replace(/\s+/g, ' ').trim();
-      return `${tag} · ${text || '(no text)'}`.slice(0, 72);
-    }
-
     function readSelectedObjectStyleState(el) {
       const frameWindow = slideIframe.contentWindow;
       const styles = frameWindow?.getComputedStyle ? frameWindow.getComputedStyle(el) : null;
@@ -1962,61 +2117,175 @@
     }
 
     function setToggleActive(button, active) {
+      if (!button) return;
       button.classList.toggle('active', Boolean(active));
       button.setAttribute('aria-pressed', active ? 'true' : 'false');
     }
 
-    function updateSelectedObjectChip(text, empty = false) {
-      selectedObjectChip.textContent = text;
-      selectedObjectChip.classList.toggle('empty', empty);
+    function setControlEnabled(button, enabled) {
+      if (!button) return;
+      button.disabled = !enabled;
+      button.setAttribute('aria-disabled', enabled ? 'false' : 'true');
     }
 
-    function updateObjectEditorControls({ preserveTextInput = false } = {}) {
-      const wasHidden = directEditControls.hidden;
-      const selected = toolMode === TOOL_MODE_SELECT ? getSelectedObjectElement() : null;
-      directEditControls.hidden = !selected;
+    function getSelectedObjectCapabilities(el) {
+      const textEditable = isTextEditableElement(el);
+      return {
+        textEditable,
+        textColorEditable: textEditable,
+        backgroundEditable: isElementNode(el),
+        sizeEditable: textEditable,
+        emphasisEditable: textEditable,
+        alignEditable: textEditable,
+      };
+    }
 
-      if (!selected) {
-        updateSelectedObjectChip('No object selected', true);
-        objectTextInput.value = '';
-        objectTextInput.disabled = true;
-        objectFontSize.value = '24';
-        objectTextColor.value = '#111111';
-        objectBgColor.value = '#ffffff';
-        setToggleActive(toggleBold, false);
-        setToggleActive(toggleItalic, false);
-        setToggleActive(toggleUnderline, false);
-        setToggleActive(toggleStrike, false);
-        setToggleActive(alignLeft, false);
-        setToggleActive(alignCenter, false);
-        setToggleActive(alignRight, false);
+    function getPopoverElement(popoverId) {
+      if (popoverId === POPOVER_TEXT) return popoverText;
+      if (popoverId === POPOVER_TEXT_COLOR) return popoverTextColor;
+      if (popoverId === POPOVER_BG_COLOR) return popoverBgColor;
+      if (popoverId === POPOVER_SIZE) return popoverSize;
+      return null;
+    }
+
+    function getPopoverTrigger(popoverId) {
+      if (popoverId === POPOVER_TEXT) return selectActionText;
+      if (popoverId === POPOVER_TEXT_COLOR) return selectActionTextColor;
+      if (popoverId === POPOVER_BG_COLOR) return selectActionBgColor;
+      if (popoverId === POPOVER_SIZE) return selectActionSize;
+      return null;
+    }
+
+    function syncPopoverInputs(snapshot) {
+      popoverTextInput.value = snapshot?.textValue || '';
+      popoverTextColorInput.value = snapshot?.textColor || '#111111';
+      popoverBgColorInput.value = snapshot?.backgroundColor || '#ffffff';
+      popoverSizeInput.value = String(snapshot?.fontSize || 24);
+    }
+
+    function hidePopover() {
+      openPopover = '';
+      [popoverText, popoverTextColor, popoverBgColor, popoverSize].forEach((popover) => {
+        if (!popover) return;
+        popover.hidden = true;
+      });
+      setToggleActive(selectActionText, false);
+      setToggleActive(selectActionTextColor, false);
+      setToggleActive(selectActionBgColor, false);
+      setToggleActive(selectActionSize, false);
+    }
+
+    function positionPopover(popover, trigger) {
+      if (!popover || !trigger || !toolPopoverLayer) return;
+      const layerRect = toolPopoverLayer.getBoundingClientRect();
+      const triggerRect = trigger.getBoundingClientRect();
+      popover.hidden = false;
+      popover.style.visibility = 'hidden';
+      popover.style.left = '0px';
+      popover.style.top = '0px';
+
+      const popRect = popover.getBoundingClientRect();
+      const maxLeft = Math.max(12, layerRect.width - popRect.width - 12);
+      const left = clamp(
+        Math.round(triggerRect.left - layerRect.left + (triggerRect.width - popRect.width) / 2),
+        12,
+        maxLeft,
+      );
+      const top = Math.max(8, Math.round(triggerRect.bottom - layerRect.top + 10));
+
+      popover.style.left = `${left}px`;
+      popover.style.top = `${top}px`;
+      popover.style.visibility = '';
+    }
+
+    function togglePopover(popoverId) {
+      const selected = toolMode === TOOL_MODE_SELECT ? getSelectedObjectElement() : null;
+      const capabilities = getSelectedObjectCapabilities(selected);
+      const enabled = (
+        (popoverId === POPOVER_TEXT && capabilities.textEditable)
+        || (popoverId === POPOVER_TEXT_COLOR && capabilities.textColorEditable)
+        || (popoverId === POPOVER_BG_COLOR && capabilities.backgroundEditable)
+        || (popoverId === POPOVER_SIZE && capabilities.sizeEditable)
+      );
+
+      if (!enabled) return;
+      if (openPopover === popoverId) {
+        hidePopover();
         return;
       }
 
-      const snapshot = readSelectedObjectStyleState(selected);
-      syncingDirectControls = true;
-      try {
-        updateSelectedObjectChip(getSelectedObjectSummary(selected), false);
-        objectTextInput.disabled = !snapshot.textEditable;
-        if (!preserveTextInput || document.activeElement !== objectTextInput) {
-          objectTextInput.value = snapshot.textEditable ? snapshot.textValue : '';
-        }
-        objectTextColor.value = snapshot.textColor;
-        objectBgColor.value = snapshot.backgroundColor;
-        objectFontSize.value = String(snapshot.fontSize);
-        setToggleActive(toggleBold, snapshot.bold);
-        setToggleActive(toggleItalic, snapshot.italic);
-        setToggleActive(toggleUnderline, snapshot.underline);
-        setToggleActive(toggleStrike, snapshot.strike);
-        setToggleActive(alignLeft, snapshot.textAlign === 'left' || snapshot.textAlign === 'start');
-        setToggleActive(alignCenter, snapshot.textAlign === 'center');
-        setToggleActive(alignRight, snapshot.textAlign === 'right' || snapshot.textAlign === 'end');
-      } finally {
-        syncingDirectControls = false;
+      const snapshot = selected ? readSelectedObjectStyleState(selected) : null;
+      syncPopoverInputs(snapshot);
+      hidePopover();
+      openPopover = popoverId;
+
+      const popover = getPopoverElement(popoverId);
+      const trigger = getPopoverTrigger(popoverId);
+      if (!popover || !trigger) return;
+
+      positionPopover(popover, trigger);
+      setToggleActive(trigger, true);
+      if (popoverId === POPOVER_TEXT) {
+        popoverTextInput.focus();
+        popoverTextInput.select();
+      } else if (popoverId === POPOVER_TEXT_COLOR) {
+        popoverTextColorInput.focus();
+      } else if (popoverId === POPOVER_BG_COLOR) {
+        popoverBgColorInput.focus();
+      } else if (popoverId === POPOVER_SIZE) {
+        popoverSizeInput.focus();
+        popoverSizeInput.select();
+      }
+    }
+
+    function updateObjectEditorControls() {
+      const selected = toolMode === TOOL_MODE_SELECT ? getSelectedObjectElement() : null;
+      const snapshot = selected ? readSelectedObjectStyleState(selected) : null;
+      const capabilities = getSelectedObjectCapabilities(selected);
+
+      if (bboxToolbar) {
+        bboxToolbar.hidden = toolMode !== TOOL_MODE_DRAW;
+      }
+      if (selectToolbar) {
+        selectToolbar.hidden = toolMode !== TOOL_MODE_SELECT;
       }
 
-      if (wasHidden !== directEditControls.hidden) {
-        scaleSlide();
+      setControlEnabled(selectActionText, capabilities.textEditable);
+      setControlEnabled(selectActionTextColor, capabilities.textColorEditable);
+      setControlEnabled(selectActionBgColor, capabilities.backgroundEditable);
+      setControlEnabled(selectActionSize, capabilities.sizeEditable);
+      setControlEnabled(toggleBold, capabilities.emphasisEditable);
+      setControlEnabled(toggleItalic, capabilities.emphasisEditable);
+      setControlEnabled(toggleUnderline, capabilities.emphasisEditable);
+      setControlEnabled(toggleStrike, capabilities.emphasisEditable);
+      setControlEnabled(alignLeft, capabilities.alignEditable);
+      setControlEnabled(alignCenter, capabilities.alignEditable);
+      setControlEnabled(alignRight, capabilities.alignEditable);
+
+      setToggleActive(toggleBold, capabilities.emphasisEditable && snapshot?.bold);
+      setToggleActive(toggleItalic, capabilities.emphasisEditable && snapshot?.italic);
+      setToggleActive(toggleUnderline, capabilities.emphasisEditable && snapshot?.underline);
+      setToggleActive(toggleStrike, capabilities.emphasisEditable && snapshot?.strike);
+      setToggleActive(alignLeft, capabilities.alignEditable && (snapshot?.textAlign === 'left' || snapshot?.textAlign === 'start'));
+      setToggleActive(alignCenter, capabilities.alignEditable && snapshot?.textAlign === 'center');
+      setToggleActive(alignRight, capabilities.alignEditable && (snapshot?.textAlign === 'right' || snapshot?.textAlign === 'end'));
+
+      if (!selected) {
+        syncPopoverInputs(null);
+        hidePopover();
+        return;
+      }
+
+      syncPopoverInputs(snapshot);
+      if (openPopover) {
+        const popover = getPopoverElement(openPopover);
+        const trigger = getPopoverTrigger(openPopover);
+        if (popover && trigger && !trigger.disabled) {
+          positionPopover(popover, trigger);
+          setToggleActive(trigger, true);
+        } else {
+          hidePopover();
+        }
       }
     }
 
@@ -2041,8 +2310,9 @@
       toolModeDrawBtn.setAttribute('aria-pressed', isDraw ? 'true' : 'false');
       toolModeSelectBtn.setAttribute('aria-pressed', !isDraw ? 'true' : 'false');
       editorHint.textContent = isDraw
-        ? 'Drag on the slide to add red pending bboxes. Cmd/Ctrl+Enter to run.'
-        : 'Click a slide object to edit its text and styles immediately.';
+        ? 'Drag on the slide to add red pending bboxes. Press Enter or Cmd/Ctrl+Enter to run.'
+        : 'Click a slide object, then use the icon toolbar to edit text and style.';
+      hidePopover();
       renderBboxes();
       renderObjectSelection();
       updateObjectEditorControls();
@@ -2056,6 +2326,9 @@
       drawBox.style.display = 'none';
       if (toolMode !== TOOL_MODE_SELECT) {
         hoveredObjectXPath = '';
+      }
+      if (toolMode !== TOOL_MODE_SELECT) {
+        hidePopover();
       }
       updateToolModeUI();
       setStatus(toolMode === TOOL_MODE_SELECT ? 'Select mode enabled.' : 'BBox draw mode enabled.');
@@ -2363,7 +2636,7 @@
       currentIndex = index;
       const slide = currentSlideFile();
       slideIframe.src = `/slides/${slide}`;
-      sessionFileChip.textContent = slide;
+      if (sessionFileChip) sessionFileChip.textContent = slide;
       slideCounter.textContent = `${currentIndex + 1} / ${slides.length}`;
       btnPrev.disabled = currentIndex === 0;
       btnNext.disabled = currentIndex === slides.length - 1;
@@ -2412,7 +2685,6 @@
           runsById.clear();
           for (const run of payload.runs || []) {
             upsertRun(run);
-            if (run.logPreview) runLogsById.set(run.runId, run.logPreview);
           }
 
           activeRunBySlide.clear();
@@ -2456,19 +2728,10 @@
         try {
           const payload = JSON.parse(event.data);
           if (!payload.runId) return;
-
-          const existing = runLogsById.get(payload.runId) || '';
-          const merged = (existing + (payload.chunk || '')).slice(-300000);
-          runLogsById.set(payload.runId, merged);
-
           const run = runsById.get(payload.runId);
           if (run) {
-            run.logPreview = merged.slice(-2000);
+            run.logPreview = (String(run.logPreview || '') + String(payload.chunk || '')).slice(-2000);
             runsById.set(payload.runId, run);
-          }
-
-          if (expandedRunId === payload.runId) {
-            renderRunsList();
           }
         } catch (error) {
           console.error('applyLog parse error:', error);
@@ -2536,7 +2799,6 @@
         runsById.clear();
         for (const run of payload.runs || []) {
           upsertRun(run);
-          if (run.logPreview) runLogsById.set(run.runId, run.logPreview);
         }
 
         activeRunBySlide.clear();
@@ -2579,17 +2841,12 @@
       }
 
       const xpath = getXPath(target);
-      const tag = target.tagName.toLowerCase();
-      setSelectedObjectXPath(xpath, `Selected ${tag} on ${currentSlideFile()}.`);
+      setSelectedObjectXPath(xpath, `Object selected on ${currentSlideFile()}.`);
     });
     window.addEventListener('mousemove', moveDrawing);
     window.addEventListener('mouseup', endDrawing);
 
     btnSend.addEventListener('click', applyChanges);
-
-    btnToggleLogs.addEventListener('click', () => {
-      setLogsVisible(!logsVisible);
-    });
 
     modelSelect.addEventListener('change', () => {
       const nextModel = normalizeModelName(modelSelect.value);
@@ -2619,33 +2876,53 @@
       updateSendState();
     });
 
-    objectTextInput.addEventListener('input', () => {
-      if (syncingDirectControls || objectTextInput.disabled) return;
-      mutateSelectedObject((el) => {
-        el.textContent = objectTextInput.value;
-      }, 'Object text updated and saved.', { delay: 180, preserveTextInput: true });
+    selectActionText.addEventListener('click', () => {
+      togglePopover(POPOVER_TEXT);
     });
 
-    objectFontSize.addEventListener('input', () => {
-      if (syncingDirectControls) return;
-      const size = clamp(Number.parseInt(objectFontSize.value || '24', 10) || 24, 8, 180);
+    selectActionTextColor.addEventListener('click', () => {
+      togglePopover(POPOVER_TEXT_COLOR);
+    });
+
+    selectActionBgColor.addEventListener('click', () => {
+      togglePopover(POPOVER_BG_COLOR);
+    });
+
+    selectActionSize.addEventListener('click', () => {
+      togglePopover(POPOVER_SIZE);
+    });
+
+    popoverApplyText.addEventListener('click', () => {
+      if (selectActionText.disabled) return;
+      mutateSelectedObject((el) => {
+        el.textContent = popoverTextInput.value;
+      }, 'Object text updated and saved.', { delay: 120 });
+      hidePopover();
+    });
+
+    popoverApplySize.addEventListener('click', () => {
+      if (selectActionSize.disabled) return;
+      const size = clamp(Number.parseInt(popoverSizeInput.value || '24', 10) || 24, 8, 180);
       mutateSelectedObject((el) => {
         el.style.fontSize = `${size}px`;
       }, 'Object font size updated and saved.');
+      hidePopover();
     });
 
-    objectTextColor.addEventListener('input', () => {
-      if (syncingDirectControls) return;
+    popoverApplyTextColor.addEventListener('click', () => {
+      if (selectActionTextColor.disabled) return;
       mutateSelectedObject((el) => {
-        el.style.color = objectTextColor.value;
+        el.style.color = popoverTextColorInput.value;
       }, 'Object text color updated and saved.');
+      hidePopover();
     });
 
-    objectBgColor.addEventListener('input', () => {
-      if (syncingDirectControls) return;
+    popoverApplyBgColor.addEventListener('click', () => {
+      if (selectActionBgColor.disabled) return;
       mutateSelectedObject((el) => {
-        el.style.backgroundColor = objectBgColor.value;
+        el.style.backgroundColor = popoverBgColorInput.value;
       }, 'Object background color updated and saved.');
+      hidePopover();
     });
 
     toggleBold.addEventListener('click', () => {
@@ -2695,19 +2972,23 @@
     });
 
     document.addEventListener('keydown', (event) => {
-      const inTextarea = document.activeElement === promptInput;
+      const inPromptField = document.activeElement === promptInput;
 
-      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+      if (
+        ((event.ctrlKey || event.metaKey) && event.key === 'Enter')
+        || (inPromptField && event.key === 'Enter')
+      ) {
         event.preventDefault();
         applyChanges();
         return;
       }
 
       if (event.key === 'Escape') {
+        hidePopover();
         return;
       }
 
-      if (inTextarea) return;
+      if (inPromptField) return;
 
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
@@ -2734,12 +3015,18 @@
       updateSendState();
     });
 
+    document.addEventListener('mousedown', (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (target.closest('#slide-toolbox') || target.closest('#tool-popover-layer')) return;
+      hidePopover();
+    });
+
     // -------------------------------------------------------------------------
     // Init
     // -------------------------------------------------------------------------
     async function init() {
       setStatus('Loading slide list...');
-      setLogsVisible(false);
 
       try {
         const res = await fetch('/api/slides');

--- a/src/editor/editor.html
+++ b/src/editor/editor.html
@@ -278,6 +278,7 @@
     }
 
     .tool-icon-btn {
+      position: relative;
       border: 1px solid #2c3847;
       background: #141c26;
       color: #d9e5f3;
@@ -851,8 +852,9 @@
     }
 
     .prompt-shell {
-      flex: 1;
-      min-width: 220px;
+      flex: 1 1 0;
+      min-width: 0;
+      display: flex;
     }
 
     .context-chips {
@@ -917,7 +919,8 @@
 
     .prompt-input {
       flex: 1;
-      min-width: 220px;
+      width: 100%;
+      min-width: 0;
       height: 46px;
       border-radius: 12px;
       border: 1px solid #2e3948;
@@ -1226,6 +1229,59 @@
       white-space: nowrap;
     }
 
+    .selected-object-mini {
+      display: inline-flex;
+      align-items: center;
+      height: 34px;
+      max-width: 200px;
+      padding: 0 10px;
+      border-radius: 8px;
+      border: 1px solid #2f3c4d;
+      background: #111a24;
+      color: #9aa8b8;
+      font-size: 11px;
+      font-family: var(--mono);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      flex: 0 0 auto;
+    }
+
+    .selected-object-mini .mini-tag {
+      color: #60a5fa;
+      font-weight: 700;
+      margin-right: 3px;
+    }
+
+    .toolbar-group-label {
+      color: var(--text-2);
+      font-size: 9px;
+      font-family: var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      flex: 0 0 auto;
+      white-space: nowrap;
+    }
+
+    .color-indicator {
+      position: absolute;
+      bottom: 5px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 18px;
+      height: 3px;
+      border-radius: 1.5px;
+      pointer-events: none;
+    }
+
+    .select-empty-hint {
+      color: var(--text-2);
+      font-size: 12px;
+      font-family: var(--mono);
+      padding: 0 4px;
+      white-space: nowrap;
+    }
+
     @media (max-width: 1380px) {
       .slide-toolbox {
         width: calc(100% - 8px);
@@ -1290,67 +1346,102 @@
               </button>
             </div>
             <div class="select-toolbar" id="select-toolbar" hidden>
+              <span class="selected-object-mini" id="selected-object-mini" style="display:none">
+                <span class="mini-tag" id="mini-tag"></span>
+                <span id="mini-text"></span>
+              </span>
+              <span class="select-empty-hint" id="select-empty-hint">Click an object to select</span>
+              <div class="toolbar-divider" aria-hidden="true"></div>
+              <span class="toolbar-group-label">Edit</span>
               <button type="button" class="tool-icon-btn" id="select-action-text" title="Edit text">
                 <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M5 6h14M12 6v12M8 18h8"/>
+                  <path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/>
                 </svg>
               </button>
               <button type="button" class="tool-icon-btn" id="select-action-text-color" title="Text color">
                 <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="m9 15 3-9 3 9M10.5 11h3"/>
-                  <path d="M6 19h12"/>
                 </svg>
+                <span class="color-indicator" id="text-color-indicator" style="background:#888"></span>
               </button>
               <button type="button" class="tool-icon-btn" id="select-action-bg-color" title="Background color">
                 <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M5 7h14v10H5z"/>
-                  <path d="M7 17h10"/>
+                  <path d="m19 11-8-8-8.6 8.6a2 2 0 0 0 0 2.8l5.2 5.2a2 2 0 0 0 2.8 0L19 11Z"/><path d="m5 2 5 5"/>
                 </svg>
+                <span class="color-indicator" id="bg-color-indicator" style="background:#888"></span>
               </button>
               <button type="button" class="tool-icon-btn" id="select-action-size" title="Font size">
                 <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M7 18 12 6l5 12M9.5 12h5"/>
+                  <path d="M4 7V4h16v3M9 20h6M12 4v16"/>
                 </svg>
               </button>
               <div class="toolbar-divider" aria-hidden="true"></div>
-              <button type="button" class="tool-icon-btn style-toggle" id="toggle-bold" title="Bold">B</button>
-              <button type="button" class="tool-icon-btn style-toggle" id="toggle-italic" title="Italic">I</button>
-              <button type="button" class="tool-icon-btn style-toggle" id="toggle-underline" title="Underline">U</button>
-              <button type="button" class="tool-icon-btn style-toggle" id="toggle-strike" title="Strikethrough">S</button>
+              <span class="toolbar-group-label">Style</span>
+              <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-bold" title="Bold (⌘B)">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 12a4 4 0 0 0 0-8H6v8"/><path d="M15 20a4 4 0 0 0 0-8H6v8"/>
+                </svg>
+              </button>
+              <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-italic" title="Italic (⌘I)">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M19 4h-9M14 20H5M15 4 9 20"/>
+                </svg>
+              </button>
+              <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-underline" title="Underline (⌘U)">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M6 4v6a6 6 0 0 0 12 0V4"/><path d="M4 20h16"/>
+                </svg>
+              </button>
+              <button type="button" class="tool-icon-btn style-toggle tight" id="toggle-strike" title="Strikethrough">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><path d="M4 12h16"/>
+                </svg>
+              </button>
               <div class="toolbar-divider" aria-hidden="true"></div>
-              <button type="button" class="tool-icon-btn align-btn" id="align-left" title="Align left">L</button>
-              <button type="button" class="tool-icon-btn align-btn" id="align-center" title="Align center">C</button>
-              <button type="button" class="tool-icon-btn align-btn" id="align-right" title="Align right">R</button>
+              <span class="toolbar-group-label">Align</span>
+              <button type="button" class="tool-icon-btn align-btn tight" id="align-left" title="Align left">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M21 6H3M15 12H3M17 18H3"/>
+                </svg>
+              </button>
+              <button type="button" class="tool-icon-btn align-btn tight" id="align-center" title="Align center">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M21 6H3M17 12H7M19 18H5"/>
+                </svg>
+              </button>
+              <button type="button" class="tool-icon-btn align-btn tight" id="align-right" title="Align right">
+                <svg class="tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M21 6H3M21 12H9M21 18H7"/>
+                </svg>
+              </button>
             </div>
           </div>
-          <div class="tool-popover-layer" id="tool-popover-layer">
-            <section class="toolbar-popover" id="editor-popover-text" hidden>
+          <div class="tool-popovers tool-popover-layer" id="tool-popover-layer">
+            <section class="editor-popover" id="editor-popover-text" hidden>
               <label class="popover-field" for="popover-text-input">
                 <span class="popover-label">Text</span>
                 <input id="popover-text-input" class="popover-input" type="text" placeholder="Edit selected text">
               </label>
               <button type="button" class="popover-apply-btn" id="popover-apply-text">Apply</button>
             </section>
-            <section class="toolbar-popover" id="editor-popover-size" hidden>
+            <section class="editor-popover" id="editor-popover-size" hidden>
               <label class="popover-field" for="popover-size-input">
                 <span class="popover-label">Size</span>
                 <input id="popover-size-input" class="popover-input popover-number" type="number" min="8" max="180" step="1" value="24">
               </label>
               <button type="button" class="popover-apply-btn" id="popover-apply-size">Apply</button>
             </section>
-            <section class="toolbar-popover" id="editor-popover-text-color" hidden>
+            <section class="editor-popover" id="editor-popover-text-color" hidden>
               <label class="popover-field" for="popover-text-color-input">
                 <span class="popover-label">Text color</span>
                 <input id="popover-text-color-input" class="popover-color" type="color" value="#111111">
               </label>
-              <button type="button" class="popover-apply-btn" id="popover-apply-text-color">Apply</button>
             </section>
-            <section class="toolbar-popover" id="editor-popover-bg-color" hidden>
+            <section class="editor-popover" id="editor-popover-bg-color" hidden>
               <label class="popover-field" for="popover-bg-color-input">
                 <span class="popover-label">Background</span>
                 <input id="popover-bg-color-input" class="popover-color" type="color" value="#ffffff">
               </label>
-              <button type="button" class="popover-apply-btn" id="popover-apply-bg-color">Apply</button>
             </section>
           </div>
           <div class="hint" id="editor-hint">Drag on the slide to add red pending bboxes. Press Enter to run.</div>
@@ -1457,10 +1548,10 @@
     const popoverApplyText = $('#popover-apply-text');
     const popoverTextColor = $('#editor-popover-text-color');
     const popoverTextColorInput = $('#popover-text-color-input');
-    const popoverApplyTextColor = $('#popover-apply-text-color');
+
     const popoverBgColor = $('#editor-popover-bg-color');
     const popoverBgColorInput = $('#popover-bg-color-input');
-    const popoverApplyBgColor = $('#popover-apply-bg-color');
+
     const popoverSize = $('#editor-popover-size');
     const popoverSizeInput = $('#popover-size-input');
     const popoverApplySize = $('#popover-apply-size');
@@ -1474,6 +1565,12 @@
     const bboxCountEl = $('#bbox-count');
     const btnSend = $('#btn-send');
     const editorHint = $('#editor-hint');
+    const selectedObjectMini = $('#selected-object-mini');
+    const miniTag = $('#mini-tag');
+    const miniText = $('#mini-text');
+    const selectEmptyHint = $('#select-empty-hint');
+    const textColorIndicator = $('#text-color-indicator');
+    const bgColorIndicator = $('#bg-color-indicator');
 
     const statusDot = $('#status-dot');
     const statusConn = $('#status-connection');
@@ -2250,6 +2347,28 @@
         selectToolbar.hidden = toolMode !== TOOL_MODE_SELECT;
       }
 
+      if (selectedObjectMini && selectEmptyHint) {
+        if (selected) {
+          const tag = selected.tagName.toLowerCase();
+          const fullText = (selected.textContent || '').trim();
+          const preview = fullText.slice(0, 24);
+          miniTag.textContent = `<${tag}>`;
+          miniText.textContent = preview ? ` ${preview}${fullText.length > 24 ? '\u2026' : ''}` : '';
+          selectedObjectMini.style.display = '';
+          selectEmptyHint.style.display = 'none';
+        } else {
+          selectedObjectMini.style.display = 'none';
+          selectEmptyHint.style.display = toolMode === TOOL_MODE_SELECT ? '' : 'none';
+        }
+      }
+
+      if (textColorIndicator) {
+        textColorIndicator.style.background = snapshot?.textColor || '#888';
+      }
+      if (bgColorIndicator) {
+        bgColorIndicator.style.background = snapshot?.backgroundColor || '#888';
+      }
+
       setControlEnabled(selectActionText, capabilities.textEditable);
       setControlEnabled(selectActionTextColor, capabilities.textColorEditable);
       setControlEnabled(selectActionBgColor, capabilities.backgroundEditable);
@@ -2311,7 +2430,7 @@
       toolModeSelectBtn.setAttribute('aria-pressed', !isDraw ? 'true' : 'false');
       editorHint.textContent = isDraw
         ? 'Drag on the slide to add red pending bboxes. Press Enter or Cmd/Ctrl+Enter to run.'
-        : 'Click a slide object, then use the icon toolbar to edit text and style.';
+        : 'Click an object to edit. Shortcuts: \u2318B bold \u00b7 \u2318I italic \u00b7 \u2318U underline';
       hidePopover();
       renderBboxes();
       renderObjectSelection();
@@ -2909,20 +3028,36 @@
       hidePopover();
     });
 
-    popoverApplyTextColor.addEventListener('click', () => {
+    // Color popovers apply in real-time via input event (no Apply button)
+
+    popoverTextInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        event.stopPropagation();
+        popoverApplyText.click();
+      }
+    });
+
+    popoverSizeInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        event.stopPropagation();
+        popoverApplySize.click();
+      }
+    });
+
+    popoverTextColorInput.addEventListener('input', () => {
       if (selectActionTextColor.disabled) return;
       mutateSelectedObject((el) => {
         el.style.color = popoverTextColorInput.value;
-      }, 'Object text color updated and saved.');
-      hidePopover();
+      }, 'Text color updated.', { delay: 300 });
     });
 
-    popoverApplyBgColor.addEventListener('click', () => {
+    popoverBgColorInput.addEventListener('input', () => {
       if (selectActionBgColor.disabled) return;
       mutateSelectedObject((el) => {
         el.style.backgroundColor = popoverBgColorInput.value;
-      }, 'Object background color updated and saved.');
-      hidePopover();
+      }, 'Background color updated.', { delay: 300 });
     });
 
     toggleBold.addEventListener('click', () => {
@@ -2973,6 +3108,13 @@
 
     document.addEventListener('keydown', (event) => {
       const inPromptField = document.activeElement === promptInput;
+
+      if (toolMode === TOOL_MODE_SELECT && (event.ctrlKey || event.metaKey) && !inPromptField) {
+        const key = event.key.toLowerCase();
+        if (key === 'b') { event.preventDefault(); if (!toggleBold.disabled) toggleBold.click(); return; }
+        if (key === 'i') { event.preventDefault(); if (!toggleItalic.disabled) toggleItalic.click(); return; }
+        if (key === 'u') { event.preventDefault(); if (!toggleUnderline.disabled) toggleUnderline.click(); return; }
+      }
 
       if (
         ((event.ctrlKey || event.metaKey) && event.key === 'Enter')

--- a/src/editor/editor.html
+++ b/src/editor/editor.html
@@ -288,6 +288,9 @@
       cursor: pointer;
       transition: background 0.15s, border-color 0.15s, color 0.15s, opacity 0.15s;
       flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .tool-icon-btn:hover {
@@ -1384,6 +1387,12 @@
       padding: 0 10px;
       outline: none;
     }
+    textarea.sidebar-input {
+      height: auto;
+      padding: 8px 10px;
+      resize: vertical;
+      line-height: 1.5;
+    }
 
     .sidebar-input:focus { border-color: #496a94; }
     .sidebar-input:disabled { opacity: 0.4; cursor: default; }
@@ -1608,7 +1617,7 @@
             <div class="sidebar-section">
               <span class="sidebar-label">Text</span>
               <div class="sidebar-field-row">
-                <input id="popover-text-input" class="sidebar-input" type="text" placeholder="Edit text...">
+                <textarea id="popover-text-input" class="sidebar-input" rows="3" placeholder="Edit text..."></textarea>
                 <button type="button" class="sidebar-btn-sm" id="popover-apply-text">Set</button>
               </div>
             </div>
@@ -2352,7 +2361,8 @@
       if (!isElementNode(el)) return false;
       const tag = el.tagName.toLowerCase();
       if (!DIRECT_TEXT_TAGS.has(tag)) return false;
-      return el.children.length === 0;
+      const INLINE_TAGS = new Set(['BR','B','STRONG','I','EM','U','S','SPAN','A','SMALL','SUB','SUP','MARK','CODE']);
+      return Array.from(el.children).every(c => INLINE_TAGS.has(c.tagName));
     }
 
     function getSelectableTargetAt(clientX, clientY) {
@@ -2398,7 +2408,7 @@
       const textDecorationLine = styles?.textDecorationLine || '';
       return {
         textEditable: isTextEditableElement(el),
-        textValue: (el.textContent || '').trim(),
+        textValue: (el.innerHTML || '').replace(/<br\s*\/?>/gi, '\n').replace(/<[^>]*>/g, '').trim(),
         textColor: normalizeHexColor(styles?.color, '#111111'),
         backgroundColor: normalizeHexColor(styles?.backgroundColor, '#ffffff'),
         fontSize: parsePixelValue(styles?.fontSize, 24),
@@ -3082,7 +3092,9 @@
     popoverApplyText.addEventListener('click', () => {
       if (popoverApplyText.disabled) return;
       mutateSelectedObject((el) => {
-        el.textContent = popoverTextInput.value;
+        const escaped = popoverTextInput.value
+          .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        el.innerHTML = escaped.replace(/\n/g, '<br>');
       }, 'Object text updated and saved.', { delay: 120 });
     });
 
@@ -3095,7 +3107,7 @@
     });
 
     popoverTextInput.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter') {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
         event.preventDefault();
         event.stopPropagation();
         popoverApplyText.click();

--- a/tests/editor/editor-ui.e2e.test.js
+++ b/tests/editor/editor-ui.e2e.test.js
@@ -422,3 +422,59 @@ test('supports direct object selection, inline styling, and switching back to bb
     await rm(workspace, { recursive: true, force: true }).catch(() => {});
   }
 });
+
+test('keeps the toolbox above the slide in a 16:9 viewport', async () => {
+  const workspace = await mkdtemp(join(os.tmpdir(), 'editor-ui-toolbox-layout-e2e-'));
+  await writeSlides(workspace);
+
+  const port = 3655;
+  const serverOutput = { value: '' };
+  const serverScriptPath = join(REPO_ROOT, 'scripts', 'editor-server.js');
+  const server = spawn(process.execPath, [serverScriptPath, '--port', String(port)], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      PPT_AGENT_PACKAGE_ROOT: REPO_ROOT,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  server.stdout.on('data', (chunk) => {
+    serverOutput.value += chunk.toString();
+  });
+  server.stderr.on('data', (chunk) => {
+    serverOutput.value += chunk.toString();
+  });
+
+  let browser;
+  try {
+    await waitForServerReady(port, server, serverOutput);
+
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({ viewport: { width: 1496, height: 768 } });
+    await page.goto(`http://localhost:${port}/`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForSelector('#slide-toolbox');
+    await page.waitForSelector('#slide-wrapper');
+    await page.waitForTimeout(500);
+
+    const toolboxBox = await page.locator('#slide-toolbox').boundingBox();
+    const wrapperBox = await page.locator('#slide-wrapper').boundingBox();
+    assert.ok(toolboxBox, 'toolbox not found');
+    assert.ok(wrapperBox, 'slide wrapper not found');
+    assert.ok(toolboxBox.y + toolboxBox.height <= wrapperBox.y, 'toolbox should stay above the slide frame');
+
+    await page.click('#tool-mode-select');
+    await page.waitForFunction(() => {
+      const button = document.querySelector('#tool-mode-select');
+      return button && button.classList.contains('active');
+    });
+  } finally {
+    if (browser) {
+      await browser.close().catch(() => {});
+    }
+    server.kill('SIGTERM');
+    await sleep(400);
+    await rm(workspace, { recursive: true, force: true }).catch(() => {});
+  }
+});

--- a/tests/editor/editor-ui.e2e.test.js
+++ b/tests/editor/editor-ui.e2e.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
@@ -288,6 +288,130 @@ test('keeps chat and model state per slide session', async () => {
       const node = document.querySelector('#chat-messages');
       const text = node?.textContent || '';
       return /slide-01 prompt/.test(text) && !/slide-02 prompt/.test(text);
+    });
+  } finally {
+    if (browser) {
+      await browser.close().catch(() => {});
+    }
+    server.kill('SIGTERM');
+    await sleep(400);
+    await rm(workspace, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test('supports direct object selection, inline styling, and switching back to bbox mode', async () => {
+  const workspace = await mkdtemp(join(os.tmpdir(), 'editor-ui-direct-edit-e2e-'));
+  await writeSlides(workspace);
+
+  const port = 3654;
+  const serverOutput = { value: '' };
+  const serverScriptPath = join(REPO_ROOT, 'scripts', 'editor-server.js');
+  const server = spawn(process.execPath, [serverScriptPath, '--port', String(port)], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      PPT_AGENT_PACKAGE_ROOT: REPO_ROOT,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  server.stdout.on('data', (chunk) => {
+    serverOutput.value += chunk.toString();
+  });
+  server.stderr.on('data', (chunk) => {
+    serverOutput.value += chunk.toString();
+  });
+
+  let browser;
+  try {
+    await waitForServerReady(port, server, serverOutput);
+
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+    await page.goto(`http://localhost:${port}/`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForSelector('#draw-layer');
+    await page.waitForSelector('#slide-iframe');
+    await page.waitForTimeout(800);
+
+    await page.click('#tool-mode-select');
+
+    const drawLayer = await page.locator('#draw-layer').boundingBox();
+    assert.ok(drawLayer, 'draw layer not found');
+
+    await page.mouse.click(
+      drawLayer.x + drawLayer.width * 0.22,
+      drawLayer.y + drawLayer.height * 0.18,
+    );
+
+    await page.waitForFunction(() => {
+      const chip = document.querySelector('#selected-object-chip');
+      return chip && /h1/i.test(chip.textContent || '');
+    });
+
+    await page.fill('#object-text-input', 'Quarterly Update');
+    await page.fill('#object-font-size', '64');
+    await page.$eval('#object-text-color', (el) => {
+      el.value = '#112233';
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await page.$eval('#object-bg-color', (el) => {
+      el.value = '#fee2e2';
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await page.click('#toggle-bold');
+    await page.click('#toggle-bold');
+    await page.click('#toggle-strike');
+    await page.click('#align-center');
+
+    await page.waitForFunction(() => {
+      const status = document.querySelector('#status-message');
+      return status && /saved|updated/i.test(status.textContent || '');
+    });
+
+    const frameHeading = page.frameLocator('#slide-iframe').locator('h1');
+    await assert.doesNotReject(async () => frameHeading.waitFor());
+    assert.equal(await frameHeading.textContent(), 'Quarterly Update');
+
+    const headingStyles = await frameHeading.evaluate((node) => {
+      const styles = window.getComputedStyle(node);
+      return {
+        color: styles.color,
+        backgroundColor: styles.backgroundColor,
+        fontWeight: styles.fontWeight,
+        textDecorationLine: styles.textDecorationLine,
+        textAlign: styles.textAlign,
+        fontSize: styles.fontSize,
+      };
+    });
+
+    assert.match(headingStyles.color, /17,\s*34,\s*51/);
+    assert.match(headingStyles.backgroundColor, /254,\s*226,\s*226/);
+    assert.ok(Number(headingStyles.fontWeight) >= 600 || /bold/i.test(headingStyles.fontWeight));
+    assert.match(headingStyles.textDecorationLine, /line-through/);
+    assert.equal(headingStyles.textAlign, 'center');
+    assert.equal(headingStyles.fontSize, '64px');
+
+    const savedHtml = await readFile(join(workspace, 'slides', 'slide-01.html'), 'utf8');
+    assert.match(savedHtml, /Quarterly Update/);
+    assert.match(savedHtml, /font-size:\s*64px/i);
+    assert.match(savedHtml, /text-align:\s*center/i);
+    assert.match(savedHtml, /line-through/i);
+    assert.match(savedHtml, /font-weight:\s*(700|bold)/i);
+    assert.match(savedHtml, /(rgb\(17,\s*34,\s*51\)|#112233)/i);
+    assert.match(savedHtml, /(rgb\(254,\s*226,\s*226\)|#fee2e2)/i);
+
+    await page.click('#tool-mode-draw');
+    await page.mouse.move(drawLayer.x + drawLayer.width * 0.08, drawLayer.y + drawLayer.height * 0.10);
+    await page.mouse.down();
+    await page.mouse.move(drawLayer.x + drawLayer.width * 0.40, drawLayer.y + drawLayer.height * 0.24, { steps: 6 });
+    await page.mouse.up();
+
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#bbox-count');
+      return el && /1 pending/.test(el.textContent || '');
     });
   } finally {
     if (browser) {

--- a/tests/editor/editor-ui.e2e.test.js
+++ b/tests/editor/editor-ui.e2e.test.js
@@ -59,7 +59,7 @@ async function waitForServerReady(port, child, outputRef) {
   throw new Error(`server did not become ready\n${outputRef.value}`);
 }
 
-test('supports multi-bbox selection and delete in chat composer flow', async () => {
+test('supports multi-bbox selection and delete in the redesigned bbox toolbar flow', { concurrency: false }, async () => {
   const workspace = await mkdtemp(join(os.tmpdir(), 'editor-ui-e2e-'));
   await writeSlides(workspace);
 
@@ -92,7 +92,9 @@ test('supports multi-bbox selection and delete in chat composer flow', async () 
 
     await page.waitForSelector('#draw-layer');
     await page.waitForTimeout(800);
-    assert.equal(await page.locator('#runs-section.collapsed').count(), 1, 'runs should be hidden by default');
+    assert.equal(await page.locator('.sidebar').count(), 0, 'sidebar should be removed in redesigned editor');
+    const promptTag = await page.$eval('#prompt-input', (el) => el.tagName);
+    assert.equal(promptTag, 'INPUT', 'bbox prompt should be a single-line input in the top toolbar');
 
     const drawLayer = await page.locator('#draw-layer').boundingBox();
     assert.ok(drawLayer, 'draw layer not found');
@@ -188,7 +190,7 @@ test('supports multi-bbox selection and delete in chat composer flow', async () 
   }
 });
 
-test('keeps chat and model state per slide session', async () => {
+test('keeps bbox prompt draft and model state per slide session', { concurrency: false }, async () => {
   const workspace = await mkdtemp(join(os.tmpdir(), 'editor-ui-session-e2e-'));
   await writeSlides(workspace);
 
@@ -222,37 +224,9 @@ test('keeps chat and model state per slide session', async () => {
     await page.waitForSelector('#draw-layer');
     await page.waitForTimeout(800);
 
-    const drawLayer = await page.locator('#draw-layer').boundingBox();
-    assert.ok(drawLayer, 'draw layer not found');
-
-    let runNum = 0;
-    await page.route('**/api/apply', async (route) => {
-      runNum += 1;
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          runId: `run-session-${runNum}`,
-          code: 0,
-          message: `ok-${runNum}`,
-        }),
-      });
-    });
-
     // slide-01
     await page.selectOption('#model-select', 'gpt-5.3-codex-spark');
-    await page.mouse.move(drawLayer.x + drawLayer.width * 0.08, drawLayer.y + drawLayer.height * 0.08);
-    await page.mouse.down();
-    await page.mouse.move(drawLayer.x + drawLayer.width * 0.40, drawLayer.y + drawLayer.height * 0.24, { steps: 6 });
-    await page.mouse.up();
     await page.fill('#prompt-input', 'slide-01 prompt');
-    await page.click('#btn-send');
-
-    await page.waitForFunction(() => {
-      const node = document.querySelector('#chat-messages');
-      return node && /slide-01 prompt/.test(node.textContent || '');
-    });
 
     // slide-02
     await page.click('#btn-next');
@@ -261,18 +235,7 @@ test('keeps chat and model state per slide session', async () => {
       return counter && /2\s*\/\s*2/.test(counter.textContent || '');
     });
     await page.selectOption('#model-select', 'gpt-5.3-codex');
-    await page.mouse.move(drawLayer.x + drawLayer.width * 0.14, drawLayer.y + drawLayer.height * 0.34);
-    await page.mouse.down();
-    await page.mouse.move(drawLayer.x + drawLayer.width * 0.52, drawLayer.y + drawLayer.height * 0.58, { steps: 6 });
-    await page.mouse.up();
     await page.fill('#prompt-input', 'slide-02 prompt');
-    await page.click('#btn-send');
-
-    await page.waitForFunction(() => {
-      const node = document.querySelector('#chat-messages');
-      const text = node?.textContent || '';
-      return /slide-02 prompt/.test(text) && !/slide-01 prompt/.test(text);
-    });
 
     // back to slide-01
     await page.click('#btn-prev');
@@ -283,12 +246,18 @@ test('keeps chat and model state per slide session', async () => {
 
     const restoredModel = await page.$eval('#model-select', (el) => el.value);
     assert.equal(restoredModel, 'gpt-5.3-codex-spark');
+    const restoredPrompt = await page.$eval('#prompt-input', (el) => el.value);
+    assert.equal(restoredPrompt, 'slide-01 prompt');
 
+    await page.click('#btn-next');
     await page.waitForFunction(() => {
-      const node = document.querySelector('#chat-messages');
-      const text = node?.textContent || '';
-      return /slide-01 prompt/.test(text) && !/slide-02 prompt/.test(text);
+      const counter = document.querySelector('#slide-counter');
+      return counter && /2\s*\/\s*2/.test(counter.textContent || '');
     });
+    const slide2Model = await page.$eval('#model-select', (el) => el.value);
+    const slide2Prompt = await page.$eval('#prompt-input', (el) => el.value);
+    assert.equal(slide2Model, 'gpt-5.3-codex');
+    assert.equal(slide2Prompt, 'slide-02 prompt');
   } finally {
     if (browser) {
       await browser.close().catch(() => {});
@@ -299,7 +268,7 @@ test('keeps chat and model state per slide session', async () => {
   }
 });
 
-test('supports direct object selection, inline styling, and switching back to bbox mode', async () => {
+test('supports direct object selection through popovers and switching back to bbox mode', { concurrency: false }, async () => {
   const workspace = await mkdtemp(join(os.tmpdir(), 'editor-ui-direct-edit-e2e-'));
   await writeSlides(workspace);
 
@@ -335,6 +304,12 @@ test('supports direct object selection, inline styling, and switching back to bb
     await page.waitForTimeout(800);
 
     await page.click('#tool-mode-select');
+    await page.waitForFunction(() => {
+      const textBtn = document.querySelector('#select-action-text');
+      const sizeBtn = document.querySelector('#select-action-size');
+      return textBtn && sizeBtn && textBtn.hasAttribute('disabled') && sizeBtn.hasAttribute('disabled');
+    });
+    assert.equal(await page.locator('#selected-object-chip').count(), 0, 'selected object chip should be removed');
 
     const drawLayer = await page.locator('#draw-layer').boundingBox();
     assert.ok(drawLayer, 'draw layer not found');
@@ -345,22 +320,43 @@ test('supports direct object selection, inline styling, and switching back to bb
     );
 
     await page.waitForFunction(() => {
-      const chip = document.querySelector('#selected-object-chip');
-      return chip && /h1/i.test(chip.textContent || '');
+      const textBtn = document.querySelector('#select-action-text');
+      const colorBtn = document.querySelector('#select-action-text-color');
+      const sizeBtn = document.querySelector('#select-action-size');
+      return textBtn && colorBtn && sizeBtn
+        && !textBtn.hasAttribute('disabled')
+        && !colorBtn.hasAttribute('disabled')
+        && !sizeBtn.hasAttribute('disabled');
     });
 
-    await page.fill('#object-text-input', 'Quarterly Update');
-    await page.fill('#object-font-size', '64');
-    await page.$eval('#object-text-color', (el) => {
+    await page.click('#select-action-text');
+    await page.waitForSelector('#editor-popover-text:not([hidden])');
+    await page.fill('#popover-text-input', 'Quarterly Update');
+    await page.click('#popover-apply-text');
+
+    await page.click('#select-action-size');
+    await page.waitForSelector('#editor-popover-size:not([hidden])');
+    await page.fill('#popover-size-input', '64');
+    await page.click('#popover-apply-size');
+
+    await page.click('#select-action-text-color');
+    await page.waitForSelector('#editor-popover-text-color:not([hidden])');
+    await page.$eval('#popover-text-color-input', (el) => {
       el.value = '#112233';
       el.dispatchEvent(new Event('input', { bubbles: true }));
       el.dispatchEvent(new Event('change', { bubbles: true }));
     });
-    await page.$eval('#object-bg-color', (el) => {
+    await page.click('#popover-apply-text-color');
+
+    await page.click('#select-action-bg-color');
+    await page.waitForSelector('#editor-popover-bg-color:not([hidden])');
+    await page.$eval('#popover-bg-color-input', (el) => {
       el.value = '#fee2e2';
       el.dispatchEvent(new Event('input', { bubbles: true }));
       el.dispatchEvent(new Event('change', { bubbles: true }));
     });
+    await page.click('#popover-apply-bg-color');
+
     await page.click('#toggle-bold');
     await page.click('#toggle-bold');
     await page.click('#toggle-strike');
@@ -423,7 +419,7 @@ test('supports direct object selection, inline styling, and switching back to bb
   }
 });
 
-test('keeps the toolbox above the slide in a 16:9 viewport', async () => {
+test('keeps the toolbox above the slide in a 16:9 viewport', { concurrency: false }, async () => {
   const workspace = await mkdtemp(join(os.tmpdir(), 'editor-ui-toolbox-layout-e2e-'));
   await writeSlides(workspace);
 
@@ -458,6 +454,7 @@ test('keeps the toolbox above the slide in a 16:9 viewport', async () => {
     await page.waitForSelector('#slide-wrapper');
     await page.waitForTimeout(500);
 
+    assert.equal(await page.locator('.sidebar').count(), 0, 'sidebar should be removed');
     const toolboxBox = await page.locator('#slide-toolbox').boundingBox();
     const wrapperBox = await page.locator('#slide-wrapper').boundingBox();
     assert.ok(toolboxBox, 'toolbox not found');
@@ -467,7 +464,8 @@ test('keeps the toolbox above the slide in a 16:9 viewport', async () => {
     await page.click('#tool-mode-select');
     await page.waitForFunction(() => {
       const button = document.querySelector('#tool-mode-select');
-      return button && button.classList.contains('active');
+      const toolbar = document.querySelector('#select-toolbar');
+      return button && toolbar && button.classList.contains('active') && !toolbar.hasAttribute('hidden');
     });
   } finally {
     if (browser) {


### PR DESCRIPTION
## Summary
- **Direct object editing**: Click any element in the slide to select it, then edit text, font size, color, background, bold/italic/underline/strikethrough, and alignment — all saved instantly to the HTML file
- **Toolbar redesign**: Replaced floating toolbar with a right sidebar panel for better ergonomics. Two tool modes: Draw (bbox) and Select (object editing)
- **Multiline & inline tag support**: Text editing now preserves `<br>`, `<span>`, `<strong>` etc. and handles multiline content correctly
- **Icon centering fix**: SVG icons in toolbar buttons now render centered

Closes #10

## Test plan
- [ ] `ppt-agent edit` → verify toolbar appears as right sidebar
- [ ] Draw mode: draw bboxes, send to Codex, review green bboxes
- [ ] Select mode: click elements → verify text/color/size/style controls work
- [ ] Edit text with `<br>` tags → verify multiline preserved
- [ ] Keyboard shortcuts: Ctrl+B/I/U in select mode, arrow keys for navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)